### PR TITLE
Fixing type conversion of properties in case of pure jRuby without seabolt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This file should follow the standards specified on [http://keepachangelog.com/]
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.3.1] 2020-01-21
+
+## Fixed
+
+- The data types of properties were in JAVA type in case of objects retunred in query for jRuby.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 
-- The data types of properties were in JAVA type in case of objects retunred in query for jRuby.
+- values Node#properties were not properly converted from java to ruby

--- a/jruby/neo4j/driver/ext/map_accessor.rb
+++ b/jruby/neo4j/driver/ext/map_accessor.rb
@@ -5,7 +5,7 @@ module Neo4j
     module Ext
       module MapAccessor
         def properties
-           keys.each_with_object({}) {|key, hash| hash[key.to_sym] = self[key] }
+          keys.each_with_object({}) { |key, hash| hash[key.to_sym] = self[key] }
         end
 
         def [](key)

--- a/jruby/neo4j/driver/ext/map_accessor.rb
+++ b/jruby/neo4j/driver/ext/map_accessor.rb
@@ -5,7 +5,7 @@ module Neo4j
     module Ext
       module MapAccessor
         def properties
-          as_map.to_hash.symbolize_keys
+           keys.each_with_object({}) {|key, hash| hash[key.to_sym] = self[key] }
         end
 
         def [](key)

--- a/jruby/neo4j/driver/ext/map_accessor.rb
+++ b/jruby/neo4j/driver/ext/map_accessor.rb
@@ -5,7 +5,7 @@ module Neo4j
     module Ext
       module MapAccessor
         def properties
-          keys.each_with_object({}) { |key, hash| hash[key.to_sym] = self[key] }
+          as_map(&:as_ruby_object).to_hash.symbolize_keys
         end
 
         def [](key)

--- a/lib/neo4j/driver/version.rb
+++ b/lib/neo4j/driver/version.rb
@@ -2,6 +2,6 @@
 
 module Neo4j
   module Driver
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/spec/integration/parameters_spec.rb
+++ b/spec/integration/parameters_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Parameters' do
 
     it 'is able to set and return Date property' do
       test_property Date.today
-      result = session.run("match(n) return n.value").single
+      result = session.run('match(n) return n.value').single
       expect(result.as_map['n.value']).to be_a(Date) if result.respond_to?(:as_map)
     end
     # skiped, no such types in ruby

--- a/spec/integration/parameters_spec.rb
+++ b/spec/integration/parameters_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe 'Parameters' do
       test_property true
     end
 
+    it 'is able to set and return Date property' do
+      test_property Date.today
+      result = session.run("match(n) return n.value").single
+      expect(result.as_map['n.value']).to be_a(Date) if result.respond_to?(:as_map)
+    end
     # skiped, no such types in ruby
     # shouldBeAbleToSetAndReturnByteProperty
     # shouldBeAbleToSetAndReturnShortProperty

--- a/spec/integration/parameters_spec.rb
+++ b/spec/integration/parameters_spec.rb
@@ -25,11 +25,6 @@ RSpec.describe 'Parameters' do
       test_property true
     end
 
-    it 'is able to set and return Date property' do
-      test_property Date.today
-      result = session.run('match(n) return n').single
-      expect(result[:n].properties[:value]).to be_a(Date)
-    end
     # skiped, no such types in ruby
     # shouldBeAbleToSetAndReturnByteProperty
     # shouldBeAbleToSetAndReturnShortProperty

--- a/spec/integration/parameters_spec.rb
+++ b/spec/integration/parameters_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe 'Parameters' do
 
     it 'is able to set and return Date property' do
       test_property Date.today
-      result = session.run('match(n) return n.value').single
-      expect(result.as_map['n.value']).to be_a(Date) if result.respond_to?(:as_map)
+      result = session.run('match(n) return n').single
+      expect(result[:n].properties[:value]).to be_a(Date)
     end
     # skiped, no such types in ruby
     # shouldBeAbleToSetAndReturnByteProperty

--- a/spec/neo4j/driver/types/node_spec.rb
+++ b/spec/neo4j/driver/types/node_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Neo4j::Driver::Types::Node do
   subject do
     session = driver.session
-    session.write_transaction { |tx| tx.run('CREATE (p:Person{name: "John"}) RETURN p').single.first }
+    session.write_transaction { |tx| tx.run('CREATE (p:Person{name: "John", created: {date}}) RETURN p', date: Date.today).single.first }
   ensure
     session&.close
   end
@@ -11,5 +11,5 @@ RSpec.describe Neo4j::Driver::Types::Node do
   it { is_expected.to be_a_kind_of described_class }
   its(:labels) { is_expected.to eq(%i[Person]) }
   its(:id) { is_expected.to be_a(Integer) }
-  its(:properties) { is_expected.to eq(name: 'John') }
+  its(:properties) { is_expected.to eq(name: 'John', created: Date.today) }
 end

--- a/spec/neo4j/driver/types/node_spec.rb
+++ b/spec/neo4j/driver/types/node_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Neo4j::Driver::Types::Node do
   ensure
     session&.close
   end
+
   let(:date) { Date.today }
+
   it { is_expected.to be_a_kind_of described_class }
   its(:labels) { is_expected.to eq(%i[Person]) }
   its(:id) { is_expected.to be_a(Integer) }

--- a/spec/neo4j/driver/types/node_spec.rb
+++ b/spec/neo4j/driver/types/node_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Neo4j::Driver::Types::Node do
   subject do
     session = driver.session
     session.write_transaction do |tx|
-      tx.run('CREATE (p:Person{name: "John", created: {date}}) RETURN p', date: Date.today).single.first
+      tx.run('CREATE (p:Person{name: "John", created: $date}) RETURN p', date: Date.today).single.first
     end
   ensure
     session&.close

--- a/spec/neo4j/driver/types/node_spec.rb
+++ b/spec/neo4j/driver/types/node_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Neo4j::Driver::Types::Node do
   subject do
     session = driver.session
     session.write_transaction do |tx|
-      tx.run('CREATE (p:Person{name: "John", created: $date}) RETURN p', date: Date.today).single.first
+      tx.run('CREATE (p:Person{name: "John", created: $date}) RETURN p', date: date).single.first
     end
   ensure
     session&.close
   end
-
+  let(:date) { Date.today }
   it { is_expected.to be_a_kind_of described_class }
   its(:labels) { is_expected.to eq(%i[Person]) }
   its(:id) { is_expected.to be_a(Integer) }
-  its(:properties) { is_expected.to eq(name: 'John', created: Date.today) }
+  its(:properties) { is_expected.to eq(name: 'John', created: date) }
 end

--- a/spec/neo4j/driver/types/node_spec.rb
+++ b/spec/neo4j/driver/types/node_spec.rb
@@ -3,7 +3,9 @@
 RSpec.describe Neo4j::Driver::Types::Node do
   subject do
     session = driver.session
-    session.write_transaction { |tx| tx.run('CREATE (p:Person{name: "John", created: {date}}) RETURN p', date: Date.today).single.first }
+    session.write_transaction do |tx|
+      tx.run('CREATE (p:Person{name: "John", created: {date}}) RETURN p', date: Date.today).single.first
+    end
   ensure
     session&.close
   end


### PR DESCRIPTION
With jRuby the properties of a node were in JAVA type. Converted them to ruby type with this PR code change. 