### PR TITLE
Fix 'modes' typo

### DIFF
--- a/ffi/neo4j/driver/types/path.rb
+++ b/ffi/neo4j/driver/types/path.rb
@@ -4,7 +4,7 @@ module Neo4j
   module Driver
     module Types
       class Path < Array
-        attr_reader :modes, :relationships
+        attr_reader :nodes, :relationships
 
         class Segment
           attr_reader :start_node, :relationship, :end_node


### PR DESCRIPTION
The paths type has an attr_accessor for :modes. I presume this is meant to be :nodes