### PR TITLE
Prevent infinite loop in error handler

### DIFF
--- a/ffi/neo4j/driver/internal/handlers/pull_all_response_handler.rb
+++ b/ffi/neo4j/driver/internal/handlers/pull_all_response_handler.rb
@@ -94,7 +94,7 @@ module Neo4j
               nil
             end
           rescue StandardError => e
-            on_failure(e)
+            on_failure(e) unless @failure
             raise e
           end
         end

--- a/spec/neo4j/driver/types_spec.rb
+++ b/spec/neo4j/driver/types_spec.rb
@@ -118,4 +118,12 @@ RSpec.describe Neo4j::Driver do
     it { is_expected.to be_a Neo4j::Driver::Types::Bytes }
     its(:encoding) { is_expected.to eq Encoding::ASCII_8BIT }
   end
+
+  context 'when unknown type' do
+    let(:param) { Class.new }
+
+    it 'raises an exception' do
+      expect { subject }.to raise_error(StandardError)
+    end
+  end
 end


### PR DESCRIPTION
The `on_failure` handler for `PullAllResponseHandler` calls `summary`, which calls `fetch`, which will in turn call `on_failure` again. This results in a stack overflow. My proposed change simply stops calling `on_failure` again once we're in error handling mode.

Prior to the fix:
![image](https://user-images.githubusercontent.com/521674/101434826-47e23d80-38d9-11eb-84c7-e97ab09dd991.png)
