### PR TITLE
Support symbols with value adapter

### DIFF
--- a/ffi/neo4j/driver/internal/value/value_adapter.rb
+++ b/ffi/neo4j/driver/internal/value/value_adapter.rb
@@ -50,6 +50,9 @@ module Neo4j
               when String
                 object = object.encode(Encoding::UTF_8) unless object.encoding == Encoding::UTF_8
                 Bolt::Value.format_as_string(value, object, object.bytesize)
+              when Symbol
+                object = object.to_s.encode(Encoding::UTF_8)
+                Bolt::Value.format_as_string(value, object, object.bytesize)
               when Hash
                 Bolt::Value.format_as_dictionary(value, object.size)
                 object.each_with_index do |(key, elem), index|

--- a/spec/neo4j/driver/types_spec.rb
+++ b/spec/neo4j/driver/types_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe Neo4j::Driver do
     it { is_expected.to eq param }
   end
 
+  context 'when Symbol' do
+    let(:param) { :symbol }
+
+    it { is_expected.to match(/^symbol$/) }
+  end
+
   context 'when Date in a map' do
     let(:param) { { date: Date.today } }
 


### PR DESCRIPTION
We have many, many ad-hoc queries (now using `ActiveGraph::Base.query`) in our application as we upgrade it from `neoj4rb` 9 to `activegraph`. Previously, `Neo4j::ActiveBase.current_session.query` which was our old method of doing ad-hoc queries, did accept symbol params. It looks like this backwards compatability was lost when `activegraph` switched to `neo4j-ruby-driver`.

The majority of these queries use a symbol for at least one of their parameters. `neo4j-ruby-driver` handles a large number of different ruby classes, it seems to me we should handle symbols as well since they are so simple to treat as strings.