### PR TITLE
Support non-UTF8 strings

### DIFF
--- a/ffi/neo4j/driver/internal/value/value_adapter.rb
+++ b/ffi/neo4j/driver/internal/value/value_adapter.rb
@@ -48,8 +48,12 @@ module Neo4j
               when Types::Bytes
                 Bolt::Value.format_as_bytes(value, object, object.size)
               when String
-                object = object.encode(Encoding::UTF_8) unless object.encoding == Encoding::UTF_8
-                Bolt::Value.format_as_string(value, object, object.bytesize)
+                if object.encoding == Encoding::ASCII_8BIT
+                  Bolt::Value.format_as_bytes(value, object, object.size)
+                else
+                  object = object.encode(Encoding::UTF_8) unless object.encoding == Encoding::UTF_8
+                  Bolt::Value.format_as_string(value, object, object.bytesize)
+                end
               when Hash
                 Bolt::Value.format_as_dictionary(value, object.size)
                 object.each_with_index do |(key, elem), index|


### PR DESCRIPTION
Another backwards compatibility issue. We insert ASCII 8bit data into String attributes on ActiveNode models. This was supported in `neoj4b` 9 with `neo4j-core`, and is supported by Seabolt, but support for such strings was removed from `neo4j-ruby-driver`in https://github.com/neo4jrb/neo4j-ruby-driver/commit/62c0ce5e33d76de9827643979a8a9fecf6a30477 but that commit does not mention why.

This change appears not to break any tests (at least in my env on MRI -- waiting to see if Travis CI points out any other failures), so if there is some failure case here, we should encode it properly in a test.

I'm not opening this PR because I think its the right change, but rather as a discussion. Should we support ASCII 8 bit strings? If not, why?