### PR TITLE
Support DateTime params

### DIFF
--- a/ffi/neo4j/driver/internal/value/value_adapter.rb
+++ b/ffi/neo4j/driver/internal/value/value_adapter.rb
@@ -63,6 +63,8 @@ module Neo4j
                 object = object.to_a
                 Bolt::Value.format_as_list(value, object.size)
                 object.each_with_index { |elem, index| to_neo(Bolt::List.value(value, index), elem) }
+              when DateTime
+                TimeWithZoneOffsetValue.to_neo(value, object)
               when Date
                 DateValue.to_neo(value, object)
               when ActiveSupport::Duration

--- a/spec/neo4j/driver/temporal_types_spec.rb
+++ b/spec/neo4j/driver/temporal_types_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Neo4j::Driver do
 
       it { is_expected.to eq param }
     end
+
+    context 'when DateTime' do
+      let(:date) { '2018-04-05 11:00' }
+      let(:param) { DateTime.parse(date) }
+
+      it { is_expected.to eq param }
+    end
   end
 
   describe 'cypher functions' do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/521674/101714210-15fee180-3a67-11eb-9049-7e43ddf5f832.png)

`DateTime` values are currently converted to `Date` values when used as a query parameter because `DateTime` is a subclass of `Date`. Found this in many examples in our codebase where we use `DateTime.current` as a parameter. We could solve this by switching to `Time.now` in our code, but I am trying to future-proof since using a `DateTime` value does NOT throw an error nor does the query log show anything wrong (because it shows the string value of the ruby object). The only reason I caught this was because one of our ActiveNode models was throwing an error that it could not convert a `Date` object to `DateTime` when reading a `property`, but I had written a `DateTime` to the field and went digging through the code.