### PR TITLE
Updated github workflow to have ruby 3.0.2 build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-18.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         ruby: [ jruby-9.2.19.0 ]
         neo4j: [ 3.5.29, 4.0.12, 4.1.10, 4.2.9, 4.3.3 ]
         driver: [ java, ruby ]
-#        driver: [ java ]
+        experimental: [false]
+        include:
+          - ruby: 3.0.2
+            neo4j: 4.3.3
+            driver: ruby
+            experimental: true
     env:
       NEO4J_EDITION_FLAG: -e
       NEO4J_VERSION: ${{ matrix.neo4j }}

--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ end.spec gem_name do
   if pdir == 'ffi'
     dependency 'ffi', '>= 0'
     dependency 'recursive-open-struct', '>= 0'
-  else
+  elsif pdir == 'jruby'
     dependency 'jar-dependencies', '>= 0'
     dependency 'ruby-maven', '>= 0', :dev
 

--- a/Rakefile
+++ b/Rakefile
@@ -49,8 +49,9 @@ end.spec gem_name do
   if pdir == 'ffi'
     dependency 'ffi', '>= 0'
     dependency 'recursive-open-struct', '>= 0'
-  elsif pdir == 'ruby'
-  else
+  # TO DO: change this condition from `RUBY_PLATFORM.match?(/java/)` to elsif `pdir == 'jruby'`
+  # after we have removed all java classes dependency from ruby driver
+  elsif RUBY_PLATFORM.match?(/java/)
     dependency 'jar-dependencies', '>= 0'
     dependency 'ruby-maven', '>= 0', :dev
 

--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,8 @@ end.spec gem_name do
   if pdir == 'ffi'
     dependency 'ffi', '>= 0'
     dependency 'recursive-open-struct', '>= 0'
-  elsif pdir == 'jruby'
+  elsif pdir == 'ruby'
+  else
     dependency 'jar-dependencies', '>= 0'
     dependency 'ruby-maven', '>= 0', :dev
 

--- a/ruby/neo4j/driver.rb
+++ b/ruby/neo4j/driver.rb
@@ -3,7 +3,7 @@
 require 'active_support/core_ext/hash/keys'
 require 'date'
 require 'loader'
-require 'neo4j-ruby-driver_jars' if RUBY_PLATFORM == 'java'
+require 'neo4j-ruby-driver_jars' if RUBY_PLATFORM.match?(/java/)
 
 # Workaround for missing zeitwerk support as of jruby-9.2.13.0
 module Neo4j

--- a/ruby/neo4j/driver.rb
+++ b/ruby/neo4j/driver.rb
@@ -3,7 +3,7 @@
 require 'active_support/core_ext/hash/keys'
 require 'date'
 require 'loader'
-require 'neo4j-ruby-driver_jars'
+require 'neo4j-ruby-driver_jars' if RUBY_PLATFORM == 'java'
 
 # Workaround for missing zeitwerk support as of jruby-9.2.13.0
 module Neo4j


### PR DESCRIPTION
- [x] updated github workflow to have ruby 3.0.2 build
- [x] Update driver to not include java classes when not using jruby