### PR TITLE
Redirect TestKit back end output to stdout/stderr

### DIFF
--- a/testkit/backend.py
+++ b/testkit/backend.py
@@ -3,10 +3,12 @@ Executed in Ruby driver container.
 Assumes driver and backend has been built.
 Responsible for starting the test backend.
 """
-import os, subprocess
+import os
+import subprocess
+import sys
 
 if __name__ == "__main__":
-    err = open("/artifacts/backenderr.log", "w")
-    out = open("/artifacts/backendout.log", "w")
     subprocess.check_call(
-        ['env', 'driver=%s' % os.environ.get("TEST_DRIVER_PLATFORM", 'ruby'), "bin/testkit-backend"], stdout=out, stderr=err)
+        ['env', 'driver=%s' % os.environ.get("TEST_DRIVER_PLATFORM", 'ruby'), "bin/testkit-backend"],
+        stdout=sys.stdout, stderr=sys.stderr
+    )


### PR DESCRIPTION
From there, TestKit can pick it up and write it into log files if desired.
https://github.com/neo4j-drivers/testkit/pull/309