### PR TITLE
Fix DriverFactory and PullAllResponseHandler to be able to connect to Neo4j Aura

### DIFF
--- a/ffi/neo4j/driver/internal/driver_factory.rb
+++ b/ffi/neo4j/driver/internal/driver_factory.rb
@@ -8,6 +8,7 @@ module Neo4j
         BOLT_URI_SCHEME = 'bolt'
         BOLT_ROUTING_URI_SCHEME = 'bolt+routing'
         NEO4J_URI_SCHEME = 'neo4j'
+        NEO4J_AURA_URI_SCHEME = 'neo4j+s'
         DEFAULT_PORT = 7687
 
         def new_instance(uri, auth_token, config)
@@ -95,7 +96,7 @@ module Neo4j
         def scheme(uri, routing_context)
           scheme = uri.scheme
           case scheme
-          when BOLT_URI_SCHEME
+          when BOLT_URI_SCHEME, NEO4J_AURA_URI_SCHEME
             assert_no_routing_context(uri, routing_context)
             Bolt::Config::BOLT_SCHEME_DIRECT
           when BOLT_ROUTING_URI_SCHEME, NEO4J_URI_SCHEME

--- a/ffi/neo4j/driver/internal/handlers/pull_all_response_handler.rb
+++ b/ffi/neo4j/driver/internal/handlers/pull_all_response_handler.rb
@@ -86,8 +86,11 @@ module Neo4j
             when -1
               check_status(Bolt::Connection.status(bolt_connection))
             when 1
-              InternalRecord.new(run_handler.statement_keys,
-                                 Value::ValueAdapter.to_ruby(Bolt::Connection.field_values(bolt_connection)))
+              values = Value::ValueAdapter.to_ruby(Bolt::Connection.field_values(bolt_connection))
+              data = run_handler.statement_keys.zip(values).to_h
+              data[:labelsOrTypes] = data[:name] if data[:labelsOrTypes] && data[:labelsOrTypes].empty?
+
+              InternalRecord.new(run_handler.statement_keys, data.values)
             else
               @finished = true
               check_summary_failure


### PR DESCRIPTION
Without these changes there are two issues.

Issue 1: The driver cannot connect to the neo4j instance
The `Neo4j::Driver::Exceptions::ClientException: Unsupported URI scheme: neo4j+s` error is thrown.
Fix: e10de99cb29c417f00a0e5e7134110bf3585c423

Issue 2: Empty `:labelsOrTypes`
Sometimes when querying (e.g. loading schema using the activegraph gem), when index records are accessed the value of `:labelsOrTypes` is an empty array (`[]`), so the code throws an `NoMethodError: undefined method `to_sym' for nil:NilClass`. This error is coming for example from here https://github.com/neo4jrb/activegraph/blob/master/lib/active_graph/core/schema.rb#L64
Fix: d71109888d9f32f7b9809abba0f2afd049c1456a