### PR TITLE
fixes #168 pack stream of specific size

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ This gem includes 2 different implementations: java driver wrapper and pure ruby
 ## Testing
 
 To run the tests the following tools need to be installed:
-
     $ brew install python
     $ pip3 install --user git+https://github.com/klobuczek/boltkit@1.3#egg=boltkit
     $ neoctrl-install -e 4.4.5 servers
@@ -56,10 +55,21 @@ $ bin/setup
 $ rspec spec
 ```
 
-In case of heap space memory error (`org.neo4j.driver.exceptions.DatabaseException: Java heap space`), you should limit the dbms memory, for example:
+Known errors:
+
+1. In case of heap space memory error (`org.neo4j.driver.exceptions.DatabaseException: Java heap space`), you should limit the dbms memory, for example:
 
 ```console
 $ neoctrl-configure servers/neo4j-enterprise-4.4.5 dbms.memory.pagecache.size=600m dbms.memory.heap.max_size=600m dbms.memory.heap.initial_size=600m dbms.directories.import= dbms.connectors.default_listen_address=::
+```
+
+2. When using command `pip3 install --user git+https://github.com/klobuczek/boltkit@1.3#egg=boltkit`, if you have m1 mac chip, you may get error when pip3 tries to install `cryptography`. Steps to take in that case (reference https://stackoverflow.com/a/70074869/2559490)
+
+```console
+$ pip uninstall cffi
+$ python -m pip install --upgrade pip
+$ pip install cffi
+$ pip install cryptography
 ```
 
 ## Contributing

--- a/ruby/neo4j/driver/internal/packstream/pack_stream.rb
+++ b/ruby/neo4j/driver/internal/packstream/pack_stream.rb
@@ -171,7 +171,7 @@ module Neo4j::Driver
             elsif size < PLUS_2_TO_THE_8
               write_byte(STRING_8).write_byte(size)
             elsif size < PLUS_2_TO_THE_16
-              write_byte(BYTES_16).write_short(size)
+              write_byte(STRING_16).write_short(size)
             else
               write_byte(STRING_32).write_int(size)
             end

--- a/ruby/neo4j/driver/version.rb
+++ b/ruby/neo4j/driver/version.rb
@@ -2,6 +2,6 @@
 
 module Neo4j
   module Driver
-    VERSION = '4.4.0.alpha.2'
+    VERSION = '4.4.0.alpha.3'
   end
 end


### PR DESCRIPTION
Issue: #168

**Cause:**  Pack stream header used for processing string of range [256, 65536) was incorrect (`BYTES_16` / `0xCD` / `205`)

**Fix:** Used correct pack stream header (`STRING_16` / `0xD1` / `209`)