### PR TITLE
Fix logging calls to old method.

### DIFF
--- a/ruby/neo4j/driver/internal/async/inbound/channel_error_handler.rb
+++ b/ruby/neo4j/driver/internal/async/inbound/channel_error_handler.rb
@@ -37,7 +37,7 @@ module Neo4j::Driver
 
           def exception_caught(ctx, error)
             if @failed
-              @error_log.trace_or_debug('Another fatal error occurred in the pipeline', error)
+              @error_log.debug('Another fatal error occurred in the pipeline', error)
             else
               @failed = true
               log_unexpected_error_warning(error)
@@ -49,7 +49,7 @@ module Neo4j::Driver
 
           def log_unexpected_error_warning(error)
             unless error.is_a?(Exceptions::ConnectionReadTimeoutException)
-              @error_log.trace_or_debug('Fatal error occurred in the pipeline', error)
+              @error_log.debug('Fatal error occurred in the pipeline', error)
             end
           end
 

--- a/ruby/neo4j/driver/internal/async/inbound/inbound_message_dispatcher.rb
+++ b/ruby/neo4j/driver/internal/async/inbound/inbound_message_dispatcher.rb
@@ -111,7 +111,7 @@ module Neo4j::Driver
               handler.on_failure(@current_error)
             end
 
-            @error_log.trace_or_debug('Closing channel because of a failure', error)
+            @error_log.debug('Closing channel because of a failure', error)
             @channel.close
           end
 


### PR DESCRIPTION
It looks like the `trace_or_debug` method was removed in #129, and replaced with a `debug` method. I found a few references to the old method and updated them in this PR.
