### PR TITLE
Fix issues with nested Sets

### DIFF
--- a/ruby/neo4j/driver/internal/cluster/routing_table_handler_impl.rb
+++ b/ruby/neo4j/driver/internal/cluster/routing_table_handler_impl.rb
@@ -63,7 +63,7 @@ module Neo4j::Driver
           addresses_to_retain = @routing_table_registry.all_servers.map(&:unicast_stream).reduce(&:+)
 
           composition_lookup_result.resolved_initial_routers&.then do |addresses|
-            addresses_to_retain << addresses
+            addresses_to_retain.merge(addresses)
           end
 
           @connection_pool.retain_all(addresses_to_retain)


### PR DESCRIPTION
Hi,

Code there is quite complex I am not 100% convinced that my solution is correct.

```ruby
        def fresh_cluster_composition_fetched(composition_lookup_result)
          @log.debug("Fetched cluster composition for database '#{@database_name.description}'. #{composition_lookup_result.cluster_composition}")
          @routing_table.update(composition_lookup_result.cluster_composition)
          @routing_table_registry.remove_aged
          addresses_to_retain = @routing_table_registry.all_servers.map(&:unicast_stream).reduce(&:+)

          composition_lookup_result.resolved_initial_routers&.then do |addresses|
            addresses_to_retain << addresses
          end

          @connection_pool.retain_all(addresses_to_retain)

          @log.debug("Updated routing table for database '#{@database_name.description}'. #{routing_table}")
          @routing_table
        rescue => error
          cluster_composition_lookup_failed(error)
        end
```

I think problem is with `<<` method here. Looks like both lines:
```ruby
@routing_table_registry.all_servers.map(&:unicast_stream).reduce(&:+)
```
```ruby
composition_lookup_result.resolved_initial_routers
```
Return a `Set`:
```ruby
irb(main):152> composition_lookup_result.resolved_initial_routers
=> #<Set: {#<Neo4j::Driver::Internal::BoltServerAddress:0x00007f39d5a8eb78 @connection_host="XXXXXX", @host="XXXXXX", @port=7687>}>
irb(main):153> ActiveGraph::Base.driver.session_factory.connection_provider.routing_table_registry.all_servers.map(&:unicast_stream).reduce(&:+)
=>
#<Set:
 {#<Neo4j::Driver::Internal::BoltServerAddress:0x00007f39d00503a0 @connection_host="XXXXXX", @host="XXXXXX", @port=7687>,
  #<Neo4j::Driver::Internal::BoltServerAddress:0x00007f39d0050080 @connection_host="XXXXXX", @host="XXXXXX", @port=7687>,
  #<Neo4j::Driver::Internal::BoltServerAddress:0x00007f39d0050710 @connection_host="XXXXXX", @host="XXXXXX", @port=7687>}>
```

By using `<<` you create nested structure:
```ruby
irb(main):001> a = Set.new
=> #<Set: {}>
irb(main):002> b = Set.new
=> #<Set: {}>
irb(main):003> a << 1
=> #<Set: {1}>
irb(main):004> b << 2
=> #<Set: {2}>
irb(main):005> a << b
=> #<Set: {1, #<Set: {2}>}>
```

Where we expect there probably sth more like:
```ruby
irb(main):001> a = Set.new
=> #<Set: {}>
irb(main):002> b = Set.new
=> #<Set: {}>
irb(main):003> a << 1
=> #<Set: {1}>
irb(main):004> b << 2
=> #<Set: {2}>
irb(main):005> a.merge(b)
=> #<Set: {1, 2}>
irb(main):006> a
=> #<Set: {1, 2}>
irb(main):007> b
=> #<Set: {2}>
```
Having nested set later fails in comparison in here:
```ruby
addresses_to_retain.include?(address)
```
https://github.com/neo4jrb/neo4j-ruby-driver/blob/19abaac79345587111c46e4ff711517a62a43dc1/ruby/neo4j/driver/internal/async/pool/connection_pool_impl.rb#L33-L35

Which later uses `==` method:
https://github.com/neo4jrb/neo4j-ruby-driver/blob/19abaac79345587111c46e4ff711517a62a43dc1/lib/neo4j/driver/internal/bolt_server_address.rb#L73-L75

If we have there nested Sets Neo4j Driver throws exceptions like:
![image](https://github.com/user-attachments/assets/58aea09d-442c-4799-b859-b81838002ae5)

Should solve issue: https://github.com/neo4jrb/neo4j-ruby-driver/issues/220

