### PR TITLE
Upgrade async gem, fix specs, dockerize project, make ruby 3.4 compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:3.4
+
+ARG JAVA_VERSION
+ENV JAVA_VERSION=$JAVA_VERSION
+
+# Adding Java package
+RUN apt install -y wget apt-transport-https gpg
+RUN wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+RUN echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+
+# Installing packages
+RUN echo "Installing Java $JAVA_VERSION"
+RUN apt-get update && apt-get upgrade -y && apt-get install -y python3-pip temurin-$JAVA_VERSION-jdk
+
+# Installing boltkit
+RUN pip3 install --user git+https://github.com/klobuczek/boltkit@1.3#egg=boltkit --break-system-packages
+RUN echo "export PATH=/root/.local/bin:$PATH" >> ~/.bashrc
+
+WORKDIR /app
+COPY . .
+RUN ./bin/setup
+
+CMD ["bundle exec rspec spec"]

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ end.spec 'neo4j-ruby-driver' do
   active_support_version = ENV['ACTIVE_SUPPORT_VERSION']
   dependency 'activesupport', active_support_version&.length&.positive? ? "~> #{active_support_version}" : '>= 5.2.0'
   # dependency 'async-rspec', '>= 0', :dev
+  dependency 'pry', '>= 0', :dev
   dependency 'ffaker', '>= 0', :dev
   dependency 'hoe', '>= 0', :dev
   dependency 'hoe-bundler', '>= 0', :dev

--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ end.spec 'neo4j-ruby-driver' do
     spec_extras[:platform] = 'java'
   else
     require_ruby_version '>= 3.1'
-    dependency 'async', '< 2.13'
+    dependency 'async', '>= 0'
     dependency 'async-io', '>= 0'
     dependency 'connection_pool', '>= 0'
   end

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,10 @@ end.spec 'neo4j-ruby-driver' do
   dependency 'rspec-mocks', '>= 0', :dev
   dependency 'zeitwerk', '>= 2.1.10'
 
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3')
+    dependency "csv", "~> 3.0", :dev
+  end
+
   spec_extras[:require_paths] = ['lib', jruby? ? 'jruby' : 'ruby']
 
   self.clean_globs += %w[Gemfile Gemfile.lock *.gemspec lib/org lib/*_jars.rb]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  ruby:
+    build:
+      context: .
+      args:
+        - JAVA_VERSION=11
+
+    volumes:
+      - .:/app
+    links:
+      - neo4j
+    environment:
+      - TEST_NEO4J_HOST=neo4j
+      - TEST_NEO4J_PORT=7687
+      - TEST_NEO4J_USER=neo4j
+      - TEST_NEO4J_PASS=pass
+      - TEST_NEO4J_SCHEME=bolt
+      - TEST_NEO4J_DATABASE=neo4j
+      - NEO4J_VERSION=4.4.5
+  neo4j:
+    image: neo4j:4.4.5-enterprise
+    ports:
+      - 7474:7474
+      - 7687:7687
+    environment:
+      - NEO4J_AUTH=neo4j/pass
+      - NEO4J_ACCEPT_LICENSE_AGREEMENT=yes

--- a/docs/dev_manual_examples.rb
+++ b/docs/dev_manual_examples.rb
@@ -10,7 +10,7 @@
 # Example 4. Hello World
 ######################################
 
-Neo4j::Driver::GraphDatabase.driver('bolt://localhost:7687',
+Neo4j::Driver::GraphDatabase.driver("bolt://#{ENV['TEST_NEO4J_HOST']}:7687",
                                     Neo4j::Driver::AuthTokens.basic('neo4j', 'pass')) do |driver|
   driver.session do |session|
     greeting = session.write_transaction do |tx|

--- a/ruby/neo4j/driver/internal/handlers/pulln/auto_pull_response_handler.rb
+++ b/ruby/neo4j/driver/internal/handlers/pulln/auto_pull_response_handler.rb
@@ -3,7 +3,7 @@ module Neo4j::Driver
     module Handlers
       module Pulln
         class AutoPullResponseHandler < BasicPullResponseHandler
-          delegate :signal, to: :@records
+          delegate :signal, to: :@queue_notification
           LONG_MAX_VALUE = 2 ** 63 - 1
 
           def initialize(query, run_response_handler, connection, metadata_extractor, completion_listener, fetch_size)
@@ -19,7 +19,8 @@ module Neo4j::Driver
               @low_record_watermark = fetch_size * 0.3
             end
 
-            @records = ::Async::Queue.new
+            @queue_notification = ::Async::Notification.new
+            @records = ::Async::Queue.new(available: @queue_notification)
             @auto_pull_enabled = true
 
             install_record_and_summary_consumers

--- a/ruby/neo4j/driver/internal/handlers/pulln/basic_pull_response_handler.rb
+++ b/ruby/neo4j/driver/internal/handlers/pulln/basic_pull_response_handler.rb
@@ -13,6 +13,7 @@ module Neo4j::Driver
             @metadata_extractor = Validator.require_non_nil!(metadata_extractor)
             @connection = Validator.require_non_nil!(connection)
             @completion_listener = Validator.require_non_nil!(completion_listener)
+            @async_notification = ::Async::Notification.new
             @state = State::READY_STATE
             @to_request = 0
           end

--- a/ruby/neo4j/driver/internal/handlers/pulln/basic_pull_response_handler.rb
+++ b/ruby/neo4j/driver/internal/handlers/pulln/basic_pull_response_handler.rb
@@ -13,7 +13,6 @@ module Neo4j::Driver
             @metadata_extractor = Validator.require_non_nil!(metadata_extractor)
             @connection = Validator.require_non_nil!(connection)
             @completion_listener = Validator.require_non_nil!(completion_listener)
-            @async_notification = ::Async::Notification.new
             @state = State::READY_STATE
             @to_request = 0
           end

--- a/spec/integration/load_csv_spec.rb
+++ b/spec/integration/load_csv_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-require 'csv'
+if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('3.3')
+  require 'csv'
+end
+
 require 'tempfile'
 
 RSpec.describe 'LoadCsv', csv: true do

--- a/spec/integration/load_csv_spec.rb
+++ b/spec/integration/load_csv_spec.rb
@@ -8,7 +8,7 @@ require 'tempfile'
 
 RSpec.describe 'LoadCsv', csv: true do
   let(:iris_class_names) { %w[Iris-setosa Iris-versicolor Iris-virginica] }
-  let(:file) { Tempfile.new('', 'tmp') }
+  let(:file) { Tempfile.new('', '/tmp') }
   let(:file_path) { file.path }
   let(:iris_data) do
     %w[sepal_length,sepal_width,petal_length,petal_width,class_name

--- a/spec/neo4j/driver/util/cc/cluster.rb
+++ b/spec/neo4j/driver/util/cc/cluster.rb
@@ -127,7 +127,7 @@ module Neo4j
           def core_member?(driver)
             driver.session(default_access_mode: Neo4j::Driver::AccessMode::READ) do |session|
               %w[LEADER FOLLOWER].include?(
-                session.run("CALL dbms.cluster.role(#{'$database' if version?('>=4')})", database: 'neo4j')
+                session.run("CALL dbms.cluster.role(#{'$database' if version?('>=4')})", database: database)
                   .single.first
               )
             end

--- a/spec/neo4j/driver/util/cc/cluster_control.rb
+++ b/spec/neo4j/driver/util/cc/cluster_control.rb
@@ -7,6 +7,7 @@ module Neo4j
         class ClusterControl
           class << self
             def install_cluster(neo4j_version, cores, read_replicas, password, port, path)
+              debug("Installing cluster at #{path}")
               execute_command('neoctrl-cluster', 'install', '--cores', cores, '--read-replicas', read_replicas,
                               '--password', password, '--initial-port', port, neo4j_version, path)
             end
@@ -20,22 +21,27 @@ module Neo4j
             end
 
             def start_cluster_member(path)
+              debug("Starting cluster member")
               execute_command('neoctrl-start', path)
             end
 
             def stop_cluster(path)
+              debug("Stopping cluster")
               execute_command('neoctrl-cluster', 'stop', path) unless debug?
             end
 
             def stop_cluster_member(path)
+              debug("Stopping cluster member")
               execute_command('neoctrl-stop', path)
             end
 
             def kill_cluster(path)
+              debug("Killing cluster")
               execute_command('neoctrl-cluster', 'stop', '--kill', path)
             end
 
             def kill_cluster_member(path)
+              debug("Killing cluster member")
               execute_command('neoctrl-stop', '--kill', path)
             end
 
@@ -66,6 +72,8 @@ module Neo4j
             def output_lines(type, base, increment, n)
               n.times.map(&method(:output_line).curry.call(type, base, increment))
             end
+
+            alias debug puts
           end
         end
       end

--- a/spec/neo4j/driver/util/cc/shared_cluster.rb
+++ b/spec/neo4j/driver/util/cc/shared_cluster.rb
@@ -43,7 +43,8 @@ module Neo4j
               # sleep(10)
 
               @cluster.members = members
-              debug("Cluster started: #{members}.")
+              debug("Cluster started:")
+              members.each { |member| debug("  #{member.bolt_uri}") }
             end
 
             def start_member(member)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'neo4j/driver'
 require 'rspec/its'
 require 'support/driver_helper'
 require 'support/neo4j_cleaner'
+require 'pry'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/support/driver_helper.rb
+++ b/spec/support/driver_helper.rb
@@ -28,6 +28,10 @@ module DriverHelper
       ENV.fetch('TEST_NEO4J_PASS', 'pass')
     end
 
+    def database
+      ENV.fetch('TEST_NEO4J_DATABASE', 'neo4j')
+    end
+
     def driver
       self.single_driver ||= Neo4j::Driver::GraphDatabase.driver(
         uri, basic_auth_token,


### PR DESCRIPTION
Hi @klobuczek 

Referring back to your comment: https://github.com/neo4jrb/neo4j-ruby-driver/pull/233#issuecomment-2407921432 

I saw you were locking `Async` gem version and trying to have green build.
I was playing a bit with neo4j-ruby-driver locally. Looks like in Async 2.13 version they changed `Queue` implementation.
Now `Queue` does not inherit from `Notification` but it is separate object that you can pass to constructor:
https://github.com/socketry/async/compare/v2.12.0...v2.13.0#diff-df8aafb695fd1c0346bb5904ac8a467d022fa17e9f018d3e337f4bc7cce0abe8R16-R21

Besides changes to the code I added Dockerfile and docker-compose for easier setup. 
I guess future contributors wouldn't like to install specific version of java or neo4j to test certain scenarios on their machines. 

Also `csv` is no longer a part of stdlib in ruby 3.4. It is a separate gem. 

Please let me know if code looks ok. I am happy to change it according to your guidance. 