### PR TITLE
Fix metadata for Hoe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Neo4j Ruby Driver
 
+home :: https://github.com/neo4jrb/neo4j-ruby-driver
+
 This repository contains 2 implementation of a Neo4j driver for Ruby:
 
 - based on official Java implementation. It provides a thin wrapper over the Java driver (only on jruby).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Neo4j Ruby Driver
 
-home :: https://github.com/neo4jrb/neo4j-ruby-driver
-
 This repository contains 2 implementation of a Neo4j driver for Ruby:
 
 - based on official Java implementation. It provides a thin wrapper over the Java driver (only on jruby).

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ HOE = Class.new(Hoe) do
   end
 end.spec 'neo4j-ruby-driver' do
   developer 'Heinrich Klobuczek', 'heinrich@mail.com'
-  self.urls = { home: 'https://github.com/neo4jrb/neo4j-ruby-driver' }
+  self.urls = { 'home' => 'https://github.com/neo4jrb/neo4j-ruby-driver' }
 
   active_support_version = ENV['ACTIVE_SUPPORT_VERSION']
   dependency 'activesupport', active_support_version&.length&.positive? ? "~> #{active_support_version}" : '>= 7.1'

--- a/Rakefile
+++ b/Rakefile
@@ -13,12 +13,13 @@ end
 
 HOE = Class.new(Hoe) do
   def read_manifest
-    Dir[*%w[README.md LICENSE.txt lib/neo4j-ruby-driver.rb lib/neo4j_ruby_driver.rb lib/neo4j-ruby-driver_loader.rb]] +
+    Dir[*%w[LICENSE.txt lib/neo4j-ruby-driver.rb lib/neo4j_ruby_driver.rb lib/neo4j-ruby-driver_loader.rb]] +
       Dir['lib/neo4j/**/*.rb'] +
       Dir["#{jruby? ? 'jruby' : 'ruby'}/**/*.rb"]
   end
 end.spec 'neo4j-ruby-driver' do
   developer 'Heinrich Klobuczek', 'heinrich@mail.com'
+  self.urls = { home: 'https://github.com/neo4jrb/neo4j-ruby-driver' }
 
   active_support_version = ENV['ACTIVE_SUPPORT_VERSION']
   dependency 'activesupport', active_support_version&.length&.positive? ? "~> #{active_support_version}" : '>= 7.1'

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ end
 
 HOE = Class.new(Hoe) do
   def read_manifest
-    Dir[*%w[LICENSE.txt lib/neo4j-ruby-driver.rb lib/neo4j_ruby_driver.rb lib/neo4j-ruby-driver_loader.rb]] +
+    Dir[*%w[README.md LICENSE.txt lib/neo4j-ruby-driver.rb lib/neo4j_ruby_driver.rb lib/neo4j-ruby-driver_loader.rb]] +
       Dir['lib/neo4j/**/*.rb'] +
       Dir["#{jruby? ? 'jruby' : 'ruby'}/**/*.rb"]
   end


### PR DESCRIPTION
In #238 I removed a line that was used by Hoe to set the gem's metadata, therefore it fails on rake tasks.

I was unable to quickly find a way to put this into the Hoe config (`self.homepage = ` didn't work), so this PR just adds the line back. Double whitespace before `::` as in the previous version of the README aren't required.