### PR TITLE
Fix docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,9 @@ The command below runs the latest Neo4j version in Docker, setting the admin use
 
 ```bash
 docker run \
-        # forward port 7474 (HTTP)
         -p7474:7474 \
-        # forward port 7687 (Bolt)
         -p7687:7687 \
-        # run in background
         -d \
-        # set login credentials
         -e NEO4J_AUTH=neo4j/password \
         neo4j:latest
 ```

--- a/README.md
+++ b/README.md
@@ -74,10 +74,14 @@ The command below runs the latest Neo4j version in Docker, setting the admin use
 
 ```bash
 docker run \
-        -p7474:7474 \                    # forward port 7474 (HTTP)
-        -p7687:7687 \                    # forward port 7687 (Bolt)
-        -d \                             # run in background
-        -e NEO4J_AUTH=neo4j/password \   # set login credentials
+        # forward port 7474 (HTTP)
+        -p7474:7474 \
+        # forward port 7687 (Bolt)
+        -p7687:7687 \
+        # run in background
+        -d \
+        # set login credentials
+        -e NEO4J_AUTH=neo4j/password \
         neo4j:latest
 ```
 


### PR DESCRIPTION
The command I added previously can't be used with copy-paste because comments are messing with syntax.