### PR TITLE
Fix routing failure handlers

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -36,6 +36,11 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
+      # Needed until runner permissions issue is resolved:
+      # https://github.com/actions/runner-images/issues/13647
+      - name: Fix gem directory permissions
+        run: sudo chmod +t $(ruby -e 'puts Gem.default_dir')/gems
+
       - name: Install ruby-maven
         run: gem install ruby-maven
 

--- a/jruby/neo4j/driver/ext/exception_mapper.rb
+++ b/jruby/neo4j/driver/ext/exception_mapper.rb
@@ -28,7 +28,7 @@ module Neo4j
         end
 
         def arguments(e)
-          [e.code, e.message, e.suppressed.map(&method(:mapped_exception))]
+          [e.code, e.message, *e.suppressed.map(&method(:mapped_exception))]
         end
 
         private

--- a/lib/neo4j/driver/exceptions/neo4j_exception.rb
+++ b/lib/neo4j/driver/exceptions/neo4j_exception.rb
@@ -7,10 +7,9 @@ module Neo4j
         attr_reader :code, :suppressed
 
         def initialize(*args)
-          @code = args.shift if args.count > 1
-          message = args.shift
-          @suppressed = args.shift
-          super(message)
+          add_suppressed(args.pop) if args.last.is_a?(Exception)
+          super(args.pop)
+          @code = args.pop
         end
 
         def add_suppressed(exception)

--- a/lib/neo4j/driver/exceptions/neo4j_exception.rb
+++ b/lib/neo4j/driver/exceptions/neo4j_exception.rb
@@ -7,13 +7,14 @@ module Neo4j
         attr_reader :code, :suppressed
 
         def initialize(*args)
-          add_suppressed(args.pop) if args.last.is_a?(Exception)
+          args, exceptions = args.partition { |arg| arg.is_a?(String) }
           super(args.pop)
           @code = args.pop
+          add_suppressed(*exceptions)
         end
 
-        def add_suppressed(exception)
-          (@suppressed ||= []) << exception
+        def add_suppressed(*exceptions)
+          (@suppressed ||= []).concat(exceptions) if exceptions.any?
         end
       end
     end

--- a/ruby/neo4j/driver/internal/async/internal_async_session.rb
+++ b/ruby/neo4j/driver/internal/async/internal_async_session.rb
@@ -32,10 +32,8 @@ module Neo4j::Driver
             tx_future = @session.begin_transaction_async(mode, ** config)
 
             tx_future.when_complete do |tx, completion_error|
-              error = Util::Futures.completion_exception_cause(completion_error)
-
-              if !error.nil?
-                result_future.complete_exceptionally(error)
+              if completion_error
+                result_future.complete_exceptionally(completion_error)
               else
                 execute_work(result_future, tx, &work)
               end
@@ -48,10 +46,8 @@ module Neo4j::Driver
           work_future = safe_execute_work(tx, &work)
 
           work_future.when_complete do |result, completion_error|
-            error = Util::Futures.completion_exception_cause(completion_error)
-
-            if !error.nil?
-              close_tx_after_failed_transaction_work(tx, result_future, error)
+            if completion_error
+              close_tx_after_failed_transaction_work(tx, result_future, completion_error)
             else
               close_tx_after_succeeded_transaction_work(tx, result_future, result)
             end
@@ -83,10 +79,8 @@ module Neo4j::Driver
 
         def close_tx_after_succeeded_transaction_work(tx, result_future, result)
           tx.close_async(true).when_complete do |_ignored, completion_error|
-            commit_error = Util::Futures.completion_exception_cause(completion_error)
-
-            if !commit_error.nil?
-              result_future.complete_exceptionally(commit_error)
+            if completion_error
+              result_future.complete_exceptionally(completion_error)
             else
               result_future.complete(result)
             end

--- a/ruby/neo4j/driver/internal/handlers/routing_response_handler.rb
+++ b/ruby/neo4j/driver/internal/handlers/routing_response_handler.rb
@@ -34,23 +34,23 @@ module Neo4j::Driver
           end
         end
 
-        def handled_service_unavailable_exception(error)
-          @error_handler.on_connection_failure(@address)
-          new_error = Exceptions::SessionExpiredException.new("Server at #{@address} is no longer available")
-          new_error.add_suppressed(error)
-          new_error
+        def handled_service_unavailable_exception(e)
+          record_connection_failure
+          Exceptions::SessionExpiredException.new("Server at #{@address} is no longer available", e)
         end
 
         def handled_transient_exception(e)
-          if e.code == "Neo.TransientError.General.DatabaseUnavailable"
-            @error_handler.on_connection_failure(@address)
-          end
+          record_connection_failure if e.code == "Neo.TransientError.General.DatabaseUnavailable"
           e
         end
 
         def handled_protocol_exception(e)
-          @error_handler.on_connection_failure(@address)
+          record_connection_failure
           e
+        end
+
+        def record_connection_failure
+          @error_handler.on_connection_failure(@address)
         end
 
         def handled_client_exception(e)

--- a/ruby/neo4j/driver/internal/handlers/routing_response_handler.rb
+++ b/ruby/neo4j/driver/internal/handlers/routing_response_handler.rb
@@ -19,10 +19,7 @@ module Neo4j::Driver
 
         private
 
-        def handled_error(received_error)
-          # TODO: probably not necessary with concurrent-ruby as it might not wrap exceptions like java
-          error = Futures.completion_exception_cause(received_error)
-
+        def handled_error(error)
           case error
           when Exceptions::ServiceUnavailableException
             handled_service_unavailable_exception(error)
@@ -37,9 +34,11 @@ module Neo4j::Driver
           end
         end
 
-        def handled_service_unavailable_exception(e)
+        def handled_service_unavailable_exception(error)
           @error_handler.on_connection_failure(@address)
-          Exceptions::SessionExpiredException.new("Server at #{@address} is no longer available")
+          new_error = Exceptions::SessionExpiredException.new("Server at #{@address} is no longer available")
+          new_error.add_suppressed(error)
+          new_error
         end
 
         def handled_transient_exception(e)

--- a/ruby/neo4j/driver/internal/handlers/routing_response_handler.rb
+++ b/ruby/neo4j/driver/internal/handlers/routing_response_handler.rb
@@ -26,6 +26,8 @@ module Neo4j::Driver
           case error
           when Exceptions::ServiceUnavailableException
             handled_service_unavailable_exception(error)
+          when Exceptions::ProtocolException
+            handled_protocol_exception(error)
           when Exceptions::ClientException
             handled_client_exception(error)
           when Exceptions::TransientException
@@ -37,11 +39,19 @@ module Neo4j::Driver
 
         def handled_service_unavailable_exception(e)
           @error_handler.on_connection_failure(@address)
-          Exceptions::SessionExpiredException("Server at #{@address} is no longer available", e)
+          Exceptions::SessionExpiredException.new("Server at #{@address} is no longer available")
         end
 
         def handled_transient_exception(e)
-          e.code == "Neo.TransientError.General.DatabaseUnavailable" ? error_handler.on_connection_failure(@address) : e
+          if e.code == "Neo.TransientError.General.DatabaseUnavailable"
+            @error_handler.on_connection_failure(@address)
+          end
+          e
+        end
+
+        def handled_protocol_exception(e)
+          @error_handler.on_connection_failure(@address)
+          e
         end
 
         def handled_client_exception(e)

--- a/ruby/neo4j/driver/internal/retry/exponential_backoff_retry_logic.rb
+++ b/ruby/neo4j/driver/internal/retry/exponential_backoff_retry_logic.rb
@@ -92,10 +92,9 @@ module Neo4j::Driver
           end
 
           work_stage.on_resolution do |fulfilled, result, completion_error|
-            error = Futures.completion_exception_cause(completion_error)
-            if error
+            if completion_error
               # work failed in async way, attempt to schedule a retry
-              retry_on_error(result_future, work, start_time, retry_delay, error, errors)
+              retry_on_error(result_future, work, start_time, retry_delay, completion_error, errors)
             else
               result_future.fulfill(result)
             end

--- a/ruby/neo4j/driver/internal/util/futures.rb
+++ b/ruby/neo4j/driver/internal/util/futures.rb
@@ -13,6 +13,9 @@ module Neo4j::Driver
         public
 
         class << self
+          # in concurrent-ruby exceptions are not wrapped like in java
+          def completion_exception_cause(error) = error
+
           def completed_with_null
             COMPLETED_WITH_NULL
           end

--- a/ruby/neo4j/driver/internal/util/futures.rb
+++ b/ruby/neo4j/driver/internal/util/futures.rb
@@ -13,9 +13,6 @@ module Neo4j::Driver
         public
 
         class << self
-          # in concurrent-ruby exceptions are not wrapped like in java
-          def completion_exception_cause(error) = error
-
           def completed_with_null
             COMPLETED_WITH_NULL
           end

--- a/spec/ruby/neo4j/driver/internal/cluster/routing_table_handler_impl_spec.rb
+++ b/spec/ruby/neo4j/driver/internal/cluster/routing_table_handler_impl_spec.rb
@@ -1,0 +1,34 @@
+require 'neo4j/driver'
+
+RSpec.describe Neo4j::Driver::Internal::Cluster::RoutingTableHandlerImpl do
+  let(:routing_table) { instance_double(Neo4j::Driver::Internal::Cluster::ClusterRoutingTable) }
+  let(:rediscovery) { instance_double(Neo4j::Driver::Internal::Cluster::RediscoveryImpl) }
+  let(:connection_pool) { instance_double(Neo4j::Driver::Internal::Async::Pool::ConnectionPoolImpl) }
+  let(:routing_table_registry) { instance_double(Neo4j::Driver::Internal::Cluster::RoutingTableRegistryImpl) }
+  let(:logger) { instance_double(Logger) }
+  let(:routing_table_purge_delay) { 30 }
+  let(:address) { instance_double(Neo4j::Driver::Internal::BoltServerAddress, to_s: "localhost:7687") }
+  
+  subject do
+    described_class.new(routing_table, rediscovery, connection_pool, routing_table_registry, logger, routing_table_purge_delay)
+  end
+
+  describe '#on_connection_failure' do
+    it 'removes server from all routing table lists' do
+      expect(routing_table).to receive(:forget).with(address)
+      subject.on_connection_failure(address)
+    end
+  end
+
+  describe '#on_write_failure' do
+    it 'removes server from writers list only' do
+      expect(routing_table).to receive(:forget_writer).with(address)
+      subject.on_write_failure(address)
+    end
+
+    it 'keeps server available for reads when NotALeader error occurs' do
+      expect(routing_table).to receive(:forget_writer).with(address)
+      subject.on_write_failure(address)
+    end
+  end
+end

--- a/spec/ruby/neo4j/driver/internal/cluster/routing_table_handler_impl_spec.rb
+++ b/spec/ruby/neo4j/driver/internal/cluster/routing_table_handler_impl_spec.rb
@@ -1,5 +1,3 @@
-require 'neo4j/driver'
-
 RSpec.describe Neo4j::Driver::Internal::Cluster::RoutingTableHandlerImpl do
   let(:routing_table) { instance_double(Neo4j::Driver::Internal::Cluster::ClusterRoutingTable) }
   let(:rediscovery) { instance_double(Neo4j::Driver::Internal::Cluster::RediscoveryImpl) }

--- a/spec/ruby/neo4j/driver/internal/handlers/routing_response_handler_spec.rb
+++ b/spec/ruby/neo4j/driver/internal/handlers/routing_response_handler_spec.rb
@@ -10,15 +10,6 @@ RSpec.describe Neo4j::Driver::Internal::Handlers::RoutingResponseHandler do
     described_class.new(delegate, address, access_mode, error_handler)
   end
 
-  before do
-    # Mock Futures.completion_exception_cause to just return the error as-is
-    stub_const("#{described_class}::Futures", Class.new do
-      def self.completion_exception_cause(error)
-        error
-      end
-    end)
-  end
-
   describe 'error handling' do
     before do
       allow(delegate).to receive(:on_failure)
@@ -33,13 +24,14 @@ RSpec.describe Neo4j::Driver::Internal::Handlers::RoutingResponseHandler do
         subject.on_failure(error)
       end
 
-      it 'transforms to SessionExpiredException' do
+      it 'transforms to SessionExpiredException and preserves original as suppressed' do
         error = Neo4j::Driver::Exceptions::ServiceUnavailableException.new("Server unavailable")
         allow(error_handler).to receive(:on_connection_failure)
         
         expect(delegate).to receive(:on_failure) do |new_error|
           expect(new_error).to be_a(Neo4j::Driver::Exceptions::SessionExpiredException)
           expect(new_error.message).to include("no longer available")
+          expect(new_error.suppressed).to include(error)
         end
         
         subject.on_failure(error)

--- a/spec/ruby/neo4j/driver/internal/handlers/routing_response_handler_spec.rb
+++ b/spec/ruby/neo4j/driver/internal/handlers/routing_response_handler_spec.rb
@@ -1,5 +1,3 @@
-require 'neo4j/driver'
-
 RSpec.describe Neo4j::Driver::Internal::Handlers::RoutingResponseHandler do
   let(:delegate) { double('delegate') }
   let(:address) { instance_double(Neo4j::Driver::Internal::BoltServerAddress, to_s: "localhost:7687") }

--- a/spec/ruby/neo4j/driver/internal/handlers/routing_response_handler_spec.rb
+++ b/spec/ruby/neo4j/driver/internal/handlers/routing_response_handler_spec.rb
@@ -1,0 +1,133 @@
+require 'neo4j/driver'
+
+RSpec.describe Neo4j::Driver::Internal::Handlers::RoutingResponseHandler do
+  let(:delegate) { double('delegate') }
+  let(:address) { instance_double(Neo4j::Driver::Internal::BoltServerAddress, to_s: "localhost:7687") }
+  let(:access_mode) { Neo4j::Driver::AccessMode::WRITE }
+  let(:error_handler) { double('error_handler') }
+  
+  subject do
+    described_class.new(delegate, address, access_mode, error_handler)
+  end
+
+  before do
+    # Mock Futures.completion_exception_cause to just return the error as-is
+    stub_const("#{described_class}::Futures", Class.new do
+      def self.completion_exception_cause(error)
+        error
+      end
+    end)
+  end
+
+  describe 'error handling' do
+    before do
+      allow(delegate).to receive(:on_failure)
+    end
+
+    context 'when ServiceUnavailableException occurs' do
+      it 'calls on_connection_failure to remove server from routing table' do
+        error = Neo4j::Driver::Exceptions::ServiceUnavailableException.new("Server unavailable")
+        
+        expect(error_handler).to receive(:on_connection_failure).with(address)
+        
+        subject.on_failure(error)
+      end
+
+      it 'transforms to SessionExpiredException' do
+        error = Neo4j::Driver::Exceptions::ServiceUnavailableException.new("Server unavailable")
+        allow(error_handler).to receive(:on_connection_failure)
+        
+        expect(delegate).to receive(:on_failure) do |new_error|
+          expect(new_error).to be_a(Neo4j::Driver::Exceptions::SessionExpiredException)
+          expect(new_error.message).to include("no longer available")
+        end
+        
+        subject.on_failure(error)
+      end
+    end
+
+    context 'when DatabaseUnavailable transient error occurs' do
+      it 'calls on_connection_failure to remove server from routing table' do
+        error = Neo4j::Driver::Exceptions::TransientException.new("Neo.TransientError.General.DatabaseUnavailable", "Database unavailable")
+        
+        expect(error_handler).to receive(:on_connection_failure).with(address)
+        
+        subject.on_failure(error)
+      end
+    end
+
+    context 'when ProtocolException occurs' do
+      it 'calls on_connection_failure to remove server from routing table' do
+        error = Neo4j::Driver::Exceptions::ProtocolException.new("Protocol violation")
+        
+        expect(error_handler).to receive(:on_connection_failure).with(address)
+        
+        subject.on_failure(error)
+      end
+
+      it 'passes through the original error' do
+        error = Neo4j::Driver::Exceptions::ProtocolException.new("Protocol violation")
+        allow(error_handler).to receive(:on_connection_failure)
+        
+        expect(delegate).to receive(:on_failure).with(error)
+        
+        subject.on_failure(error)
+      end
+    end
+
+    context 'when NotALeader error occurs in WRITE mode' do
+      it 'calls on_write_failure which removes server from writers only' do
+        error = Neo4j::Driver::Exceptions::ClientException.new("Neo.ClientError.Cluster.NotALeader", "Not a leader")
+        
+        expect(error_handler).to receive(:on_write_failure).with(address)
+        
+        subject.on_failure(error)
+      end
+
+      it 'transforms to SessionExpiredException' do
+        error = Neo4j::Driver::Exceptions::ClientException.new("Neo.ClientError.Cluster.NotALeader", "Not a leader")
+        allow(error_handler).to receive(:on_write_failure)
+        
+        expect(delegate).to receive(:on_failure) do |new_error|
+          expect(new_error).to be_a(Neo4j::Driver::Exceptions::SessionExpiredException)
+          expect(new_error.message).to include("no longer accepts writes")
+        end
+        
+        subject.on_failure(error)
+      end
+    end
+
+    context 'when ForbiddenOnReadOnlyDatabase error occurs in WRITE mode' do
+      it 'calls on_write_failure which removes server from writers only' do
+        error = Neo4j::Driver::Exceptions::ClientException.new("Neo.ClientError.General.ForbiddenOnReadOnlyDatabase", "Read only")
+        
+        expect(error_handler).to receive(:on_write_failure).with(address)
+        
+        subject.on_failure(error)
+      end
+    end
+
+    context 'when write error occurs in READ mode' do
+      let(:access_mode) { Neo4j::Driver::AccessMode::READ }
+
+      it 'does not call on_write_failure' do
+        error = Neo4j::Driver::Exceptions::ClientException.new("Neo.ClientError.Cluster.NotALeader", "Not a leader")
+        
+        expect(error_handler).not_to receive(:on_write_failure)
+        
+        subject.on_failure(error)
+      end
+
+      it 'returns ClientException about write in READ mode' do
+        error = Neo4j::Driver::Exceptions::ClientException.new("Neo.ClientError.Cluster.NotALeader", "Not a leader")
+        
+        expect(delegate).to receive(:on_failure) do |new_error|
+          expect(new_error).to be_a(Neo4j::Driver::Exceptions::ClientException)
+          expect(new_error.message).to include("Write queries cannot be performed in READ access mode")
+        end
+        
+        subject.on_failure(error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes issues with removing server from the routing table on failures (#265) and adds specs for it.