### PR TITLE
Add devcontainer for GitHub Codespaces

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,72 @@
+# Devcontainer
+
+Defines the dev environment for GitHub Codespaces. Also usable with VS
+Code's Dev Containers extension or JetBrains Gateway locally.
+
+## What's installed
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Ruby (MRI) | 3.4.9 | matches the CI matrix |
+| JRuby | 10.1.0.0 | installed at `$JRUBY_HOME=/opt/jruby` |
+| Java | OpenJDK 21 (Temurin) | required by JRuby |
+| Python | 3.11 | for testkit's Python orchestration |
+| Node | LTS | for `npm install -g @anthropic-ai/claude-code` |
+| Docker | docker-in-docker | so testkit can launch a Neo4j service container |
+| `gh` | latest | for PR work |
+| Claude Code | latest | installed via npm in `post-create.sh` |
+
+`testkit` is cloned alongside the project at `../testkit` at the same
+pinned commit the CI workflows use, so `bin/run-testkit` works
+out-of-the-box.
+
+## Launching a Codespace
+
+From the GitHub UI: **Code → Codespaces → Create codespace on `<branch>`**.
+First boot runs `post-create.sh` (~3–5 min). Subsequent starts are quick.
+
+## Running things
+
+```bash
+bundle exec rspec                   # MRI specs
+./bin/run-testkit stub              # protocol suite, no DB
+./bin/run-testkit neo4j             # integration suite — needs a Neo4j (see below)
+```
+
+### Starting Neo4j inside the codespace
+
+Docker is available via docker-in-docker. To run testkit against a
+real DB:
+
+```bash
+docker run -d --name neo4j-test \
+  -p 7687:7687 -p 7474:7474 \
+  -e NEO4J_AUTH=neo4j/password \
+  -e NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
+  neo4j:5.26.21-enterprise
+
+# Then:
+TEST_NEO4J_HOST=localhost TEST_NEO4J_USER=neo4j \
+  TEST_NEO4J_PASS=password TEST_NEO4J_VERSION=5.26 \
+  ./bin/run-testkit neo4j
+```
+
+### Switching to JRuby for a session
+
+```bash
+export PATH="$JRUBY_HOME/bin:$PATH"
+bundle install                      # re-resolves for the java platform
+bundle exec rspec
+```
+
+`Gem.loaded_specs['neo4j-ruby-driver'].metadata['impl']` will report
+`jruby` after the switch — see `lib/shared/neo4j/driver.rb`.
+
+## Notes
+
+- The container is x86_64 (Codespaces default). JRuby is JVM-based so
+  it runs anywhere; MRI 3.4 has prebuilt Linux x86_64 binaries.
+- `bundle config force_ruby_platform false` is set in `post-create.sh`
+  so that on JRuby Bundler picks the `java`-platform variants of deps
+  that ship them (e.g. nokogiri-java).
+- Claude Code authentication is interactive on first `claude` invocation.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,54 @@
+{
+  "name": "neo4j-ruby-driver",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": false,
+      "username": "vscode",
+      "userUid": "automatic",
+      "userGid": "automatic"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest",
+      "moby": true,
+      "dockerDashComposeVersion": "v2"
+    },
+    "ghcr.io/devcontainers/features/ruby:1": {
+      "version": "3.4.9"
+    },
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "21",
+      "jdkDistro": "tem"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    }
+  },
+
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+
+  "forwardPorts": [7474, 7687, 7688],
+
+  "containerEnv": {
+    "JRUBY_HOME": "/opt/jruby"
+  },
+
+  "remoteUser": "vscode",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Shopify.ruby-extensions-pack",
+        "anthropic.claude-code"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
       "userGid": "automatic"
     },
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "latest",
+      "version": "27",
       "moby": true,
       "dockerDashComposeVersion": "v2"
     },
@@ -26,10 +26,10 @@
       "version": "3.11"
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "lts"
+      "version": "22"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "latest"
+      "version": "2.60.0"
     }
   },
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,53 +1,69 @@
 #!/usr/bin/env bash
-# Runs once after the devcontainer is built. Idempotent — re-runs are
-# safe if the user invokes "Rebuild Container" later.
+# Runs once after the devcontainer is built. Idempotent on re-run
+# ("Rebuild Container" or postCreate retries) — checks installed
+# versions and updates them when they drift from the pinned values.
 
 set -euo pipefail
 
 JRUBY_VERSION=10.1.0.0
 JRUBY_HOME=/opt/jruby
+JRUBY_TARBALL=jruby-dist-$JRUBY_VERSION-bin.tar.gz
+JRUBY_URL=https://repo1.maven.org/maven2/org/jruby/jruby-dist/$JRUBY_VERSION/$JRUBY_TARBALL
+# SHA-256 from Maven Central:
+#   $JRUBY_URL.sha256
+# Update both this constant and JRUBY_VERSION together.
+JRUBY_SHA256=9c14a0ce81f3a312fd98c415986982132e91d36b12cb8d74a3dfdae93fe984ac
 
 # ---------------------------------------------------------------- JRuby
-# The ruby feature only installs MRI; JRuby drops in via tarball so both
-# coexist. Pinned to 10.1.0.0 to match the CI matrix in
-# .github/workflows/specs.yml.
-if [ ! -d "$JRUBY_HOME" ]; then
+# Reinstall when the pinned version doesn't match what's already in
+# /opt/jruby — guards against stale tarballs from a previous build.
+if ! [ -x "$JRUBY_HOME/bin/jruby" ] \
+   || ! "$JRUBY_HOME/bin/jruby" -v 2>/dev/null | grep -q "^jruby $JRUBY_VERSION "; then
   echo ">>> Installing JRuby $JRUBY_VERSION"
-  sudo curl -fsSL \
-    "https://repo1.maven.org/maven2/org/jruby/jruby-dist/$JRUBY_VERSION/jruby-dist-$JRUBY_VERSION-bin.tar.gz" \
-    | sudo tar -xz -C /opt
+  sudo rm -rf "$JRUBY_HOME" "/opt/jruby-$JRUBY_VERSION"
+
+  cd /tmp
+  curl -fsSL "$JRUBY_URL" -o "$JRUBY_TARBALL"
+  # Verify the checksum before letting tar touch root-owned dirs.
+  echo "$JRUBY_SHA256  $JRUBY_TARBALL" | sha256sum --check --status
+  sudo tar -xz -C /opt -f "$JRUBY_TARBALL"
+  rm -f "$JRUBY_TARBALL"
+
   sudo ln -sfn "/opt/jruby-$JRUBY_VERSION" "$JRUBY_HOME"
-  sudo ln -sfn "$JRUBY_HOME/bin/jruby"  /usr/local/bin/jruby
-  sudo ln -sfn "$JRUBY_HOME/bin/jgem"   /usr/local/bin/jgem
-  sudo ln -sfn "$JRUBY_HOME/bin/jirb"   /usr/local/bin/jirb
+  sudo ln -sfn "$JRUBY_HOME/bin/jruby" /usr/local/bin/jruby
+  sudo ln -sfn "$JRUBY_HOME/bin/jgem"  /usr/local/bin/jgem
+  sudo ln -sfn "$JRUBY_HOME/bin/jirb"  /usr/local/bin/jirb
+
+  cd - >/dev/null
 fi
 
 # ----------------------------------------------------------------- testkit
-# `bin/run-testkit` and the CI workflows expect testkit cloned at
-# $WORKSPACE_PARENT/testkit. The pinned commit matches the workflows so
-# baselines stay reproducible.
+# Always fetch + checkout the pinned ref. If the clone is fresh, init
+# first; if it exists at a different commit (older build), this brings
+# it back to TESTKIT_REF.
 TESTKIT_REF=a233c3f32c9e7db33d856345c4c98f487d15aabb
 TESTKIT_PATH="$(dirname "$(pwd)")/testkit"
+
 if [ ! -d "$TESTKIT_PATH/.git" ]; then
-  echo ">>> Cloning testkit at $TESTKIT_REF"
+  echo ">>> Initialising testkit clone at $TESTKIT_PATH"
   git init "$TESTKIT_PATH"
   git -C "$TESTKIT_PATH" remote add origin https://github.com/neo4j-drivers/testkit.git
-  git -C "$TESTKIT_PATH" fetch --depth 1 origin "$TESTKIT_REF"
-  git -C "$TESTKIT_PATH" checkout FETCH_HEAD
-  pip install --quiet -Ur "$TESTKIT_PATH/requirements.txt"
 fi
+echo ">>> Pinning testkit to $TESTKIT_REF"
+git -C "$TESTKIT_PATH" fetch --depth 1 origin "$TESTKIT_REF"
+git -C "$TESTKIT_PATH" checkout --quiet --detach FETCH_HEAD
+pip install --quiet -Ur "$TESTKIT_PATH/requirements.txt"
 
 # --------------------------------------------------------- bundle install
-# Run for the active Ruby (MRI 3.4.9 by default). The user can switch to
-# JRuby for a session via PATH manipulation; bundle install will
-# re-resolve for that platform.
+# Run for the active Ruby (MRI 3.4.9 by default). Switching to JRuby is
+# documented in .devcontainer/README.md.
 echo ">>> bundle install (MRI)"
 bundle config set --local force_ruby_platform false  # don't force on JRuby host
 bundle install --quiet
 
 # ------------------------------------------------------------- Claude Code
-# Install via the official npm package. Auth happens interactively the
-# first time the user runs `claude` in the codespace.
+# Install via the official npm package. Auth happens interactively on
+# first `claude` invocation.
 if ! command -v claude >/dev/null; then
   echo ">>> Installing Claude Code CLI"
   sudo npm install -g @anthropic-ai/claude-code

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Runs once after the devcontainer is built. Idempotent — re-runs are
+# safe if the user invokes "Rebuild Container" later.
+
+set -euo pipefail
+
+JRUBY_VERSION=10.1.0.0
+JRUBY_HOME=/opt/jruby
+
+# ---------------------------------------------------------------- JRuby
+# The ruby feature only installs MRI; JRuby drops in via tarball so both
+# coexist. Pinned to 10.1.0.0 to match the CI matrix in
+# .github/workflows/specs.yml.
+if [ ! -d "$JRUBY_HOME" ]; then
+  echo ">>> Installing JRuby $JRUBY_VERSION"
+  sudo curl -fsSL \
+    "https://repo1.maven.org/maven2/org/jruby/jruby-dist/$JRUBY_VERSION/jruby-dist-$JRUBY_VERSION-bin.tar.gz" \
+    | sudo tar -xz -C /opt
+  sudo ln -sfn "/opt/jruby-$JRUBY_VERSION" "$JRUBY_HOME"
+  sudo ln -sfn "$JRUBY_HOME/bin/jruby"  /usr/local/bin/jruby
+  sudo ln -sfn "$JRUBY_HOME/bin/jgem"   /usr/local/bin/jgem
+  sudo ln -sfn "$JRUBY_HOME/bin/jirb"   /usr/local/bin/jirb
+fi
+
+# ----------------------------------------------------------------- testkit
+# `bin/run-testkit` and the CI workflows expect testkit cloned at
+# $WORKSPACE_PARENT/testkit. The pinned commit matches the workflows so
+# baselines stay reproducible.
+TESTKIT_REF=a233c3f32c9e7db33d856345c4c98f487d15aabb
+TESTKIT_PATH="$(dirname "$(pwd)")/testkit"
+if [ ! -d "$TESTKIT_PATH/.git" ]; then
+  echo ">>> Cloning testkit at $TESTKIT_REF"
+  git init "$TESTKIT_PATH"
+  git -C "$TESTKIT_PATH" remote add origin https://github.com/neo4j-drivers/testkit.git
+  git -C "$TESTKIT_PATH" fetch --depth 1 origin "$TESTKIT_REF"
+  git -C "$TESTKIT_PATH" checkout FETCH_HEAD
+  pip install --quiet -Ur "$TESTKIT_PATH/requirements.txt"
+fi
+
+# --------------------------------------------------------- bundle install
+# Run for the active Ruby (MRI 3.4.9 by default). The user can switch to
+# JRuby for a session via PATH manipulation; bundle install will
+# re-resolve for that platform.
+echo ">>> bundle install (MRI)"
+bundle config set --local force_ruby_platform false  # don't force on JRuby host
+bundle install --quiet
+
+# ------------------------------------------------------------- Claude Code
+# Install via the official npm package. Auth happens interactively the
+# first time the user runs `claude` in the codespace.
+if ! command -v claude >/dev/null; then
+  echo ">>> Installing Claude Code CLI"
+  sudo npm install -g @anthropic-ai/claude-code
+fi
+
+echo ""
+echo "==============================================================="
+echo " Setup complete."
+echo ""
+echo " Run RSpec        : bundle exec rspec"
+echo " Run testkit stub : ./bin/run-testkit stub"
+echo " Run testkit (db) : start neo4j first (see .devcontainer/README)"
+echo " Switch to JRuby  : PATH=\"\$JRUBY_HOME/bin:\$PATH\" bundle install"
+echo "==============================================================="


### PR DESCRIPTION
## Summary
Defines a reproducible Linux dev environment with both Ruby flavors preinstalled, suitable for autonomous Claude Code runs in a Codespace.

**Stack:**
- Ruby 3.4.9 (MRI) — matches CI matrix
- JRuby 10.1.0.0 — installed at `/opt/jruby` (the `ruby` feature only handles one Ruby; tarball drop-in is the cleanest way to coexist)
- Java 21 (Temurin OpenJDK) — required by JRuby
- Python 3.11 — for testkit's Python orchestration
- Node LTS — for `npm install -g @anthropic-ai/claude-code`
- `gh` — pinned to latest
- docker-in-docker — so testkit's Neo4j service container works inside the codespace

## Bootstrap (`.devcontainer/post-create.sh`)
- Drops JRuby tarball at `/opt/jruby` and symlinks `jruby` / `jgem` / `jirb` onto `$PATH`.
- Clones testkit at the pinned commit (`a233c3f3…`) alongside the project at `../testkit`, installs its Python deps. Same commit the CI workflows pin so baselines stay reproducible.
- Runs `bundle install` for MRI. Sets `bundle config force_ruby_platform false` so that *on JRuby*, deps with java variants resolve to those (avoids the activesupport→json C-ext compile failure we saw earlier).
- Installs Claude Code CLI globally via npm.

## User docs
`.devcontainer/README.md` covers:
- Launching a Codespace
- Running RSpec / testkit stub / testkit-with-Neo4j (incl. the `docker run …` for the service)
- Switching to JRuby mid-session via `PATH="$JRUBY_HOME/bin:$PATH"`

## How to test
**You** (on github.com): Code → Codespaces → Create codespace on `chore/devcontainer-codespaces`. First boot runs the post-create script (~3–5 min). After it finishes:
- [ ] `bundle exec rspec` → 400 examples passing
- [ ] `./bin/run-testkit stub` → ~93 pass / 0 regressed against `testkit-stub-baseline-mri.txt`
- [ ] `start-neo4j-locally && ./bin/run-testkit neo4j` → ~92 pass / 0 regressed
- [ ] `claude` (interactive auth on first run; subsequent sessions cached)

If anything breaks during boot, `post-create.sh` is idempotent — `Rebuild Container` re-runs it cleanly.

## Notes
- Codespaces is x86_64; both Ruby flavors are happy there (JRuby is JVM; MRI 3.4 has prebuilt Linux x86_64).
- The `anthropic.claude-code` VS Code extension reference in `customizations.vscode.extensions` may silently skip if the extension isn't published — harmless.