### PR TITLE
devcontainer: drop sudo from npm install -g claude-code

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -64,9 +64,14 @@ bundle install --quiet
 # ------------------------------------------------------------- Claude Code
 # Install via the official npm package. Auth happens interactively on
 # first `claude` invocation.
+#
+# No sudo: the devcontainer Node feature (NVM-based) puts npm's prefix
+# under /usr/local/share/nvm/... which is writable by the dev user.
+# `sudo npm` strips PATH and fails with "npm: command not found" because
+# root's secure_path doesn't include the NVM dir.
 if ! command -v claude >/dev/null; then
   echo ">>> Installing Claude Code CLI"
-  sudo npm install -g @anthropic-ai/claude-code
+  npm install -g @anthropic-ai/claude-code
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
\`sudo npm install -g @anthropic-ai/claude-code\` was failing silently in fresh codespaces with \`sudo: npm: command not found\`. The Node devcontainer feature installs Node via NVM into \`/usr/local/share/nvm/...\`, which is on the dev user's \`PATH\` but **not** on root's \`secure_path\`, so \`sudo npm\` couldn't find the binary at all.

NVM-managed Node has a user-writable global prefix, so a plain \`npm install -g\` works without root. Drop sudo; comment explains the reasoning.

## Discovered by
Heinrich hit \`sudo: npm: command not found\` when manually running the same command in a fresh codespace, which means the post-create install also silently failed for any codespace built from prior devcontainer commits. Workaround for an existing codespace: \`npm install -g @anthropic-ai/claude-code\` (no sudo) or rebuild from a commit including this fix.

## Test plan
- [ ] New codespace from this branch boots with \`claude\` already on PATH (\`which claude\` non-empty).
- [ ] \`claude --version\` prints a version.