### PR TITLE
Correct cross-flavor override doc — per-gem force_ruby_platform

### DIFF
--- a/JRUBY.md
+++ b/JRUBY.md
@@ -147,20 +147,34 @@ chosen impl and branches on `STAGED_BUILD`:
   a `path:` source.
 - Staged: files = flat `lib/**/*`, `require_paths = ['lib']`.
 
-### Selecting a flavor from source
+### Selecting a flavor
 
-Consumer Gemfile (path or git source):
+Default consumer Gemfile (any source):
 
 ```ruby
-gem 'neo4j-ruby-driver', path: '../neo4j-ruby-driver'
+gem 'neo4j-ruby-driver'
+# or path: '../neo4j-ruby-driver', or git: '...'
 ```
 
-Bundler scans `*.gemspec` in the source and picks the platform-compatible
-one — ruby on MRI, java on JRuby. The loader reads `spec.metadata['impl']`
-from whichever gemspec was selected, so it stays in sync automatically.
+Bundler picks the platform-compatible gemspec — ruby on MRI, java on
+JRuby. The loader reads `spec.metadata['impl']` from whichever gemspec
+was selected, so it stays in sync automatically.
 
 To force the MRI flavor on JRuby (e.g. to develop the MRI codebase
-under JRuby), pin gemspec discovery to the MRI file via `:glob`:
+under JRuby, or to opt out of the Java-driver delegation), use the
+per-gem `force_ruby_platform: true` option:
+
+```ruby
+gem 'neo4j-ruby-driver', force_ruby_platform: true
+```
+
+This works for any source (rubygems, path, git). It scopes to *this*
+gem only — Bundler still resolves other deps to their native platform
+variants. (The global `bundle config force_ruby_platform true` is too
+coarse and would break deps with JRuby-native code like `json`.)
+
+For path sources with both gemspecs visible, the per-gem flag picks
+the ruby gemspec; equivalently you can use `glob:`:
 
 ```ruby
 gem 'neo4j-ruby-driver', path: '../neo4j-ruby-driver',
@@ -169,14 +183,6 @@ gem 'neo4j-ruby-driver', path: '../neo4j-ruby-driver',
 
 The dev tree's own Gemfile uses the `gemspec` directive instead of
 `gem`; the equivalent override is `gemspec name: 'neo4j-ruby-driver'`.
-
-For RubyGems-installed gems there is no clean per-gem override —
-`bundle config set --local force_ruby_platform true` exists but
-applies globally and breaks any other dependency that ships
-JRuby-native variants (e.g. activesupport's transitive `json` dep).
-This is a Bundler limitation, not specific to our gem. In practice,
-the cross-flavor case is a development concern and the path/git
-override above covers it.
 
 ### What the user sees after install
 

--- a/lib/shared/neo4j/driver.rb
+++ b/lib/shared/neo4j/driver.rb
@@ -12,11 +12,11 @@ require 'zeitwerk'
 module Neo4j
   module Driver
     # Picked from the gemspec Bundler/RubyGems actually selected, via
-    # spec.metadata['impl']. Stays correct when the user pins gemspec
-    # discovery (e.g. `glob: 'neo4j-ruby-driver.gemspec'` from a JRuby
-    # host to develop the MRI flavor), where RUBY_PLATFORM and the
-    # loaded gem disagree. Falls back to RUBY_PLATFORM when the spec
-    # isn't visible (raw source tree without RubyGems activation).
+    # spec.metadata['impl']. Stays correct when the user opts into the
+    # MRI flavor on JRuby (e.g. `gem 'neo4j-ruby-driver',
+    # force_ruby_platform: true` in their Gemfile), where RUBY_PLATFORM
+    # and the loaded gem disagree. Falls back to RUBY_PLATFORM when the
+    # spec isn't visible (raw source tree without RubyGems activation).
     def self.implementation
       declared = Gem.loaded_specs['neo4j-ruby-driver']&.metadata&.fetch('impl', nil)
       return declared.to_sym if declared


### PR DESCRIPTION
## Summary
JRUBY.md and the loader's comment claimed there was no clean per-gem override for the cross-flavor case (MRI flavor on JRuby). That was wrong — Bundler's Gemfile DSL accepts \`force_ruby_platform: true\` as a per-gem option that scopes the platform flip to that one dep, leaving everything else to resolve natively:

\`\`\`ruby
gem 'neo4j-ruby-driver', force_ruby_platform: true
\`\`\`

This works for any source (rubygems, path, git), so it's the canonical way for a JRuby user to opt into the MRI flavor.

## Diff
- JRUBY.md "Selecting a flavor" section now leads with the per-gem option, with \`glob:\` / \`gemspec name:\` as equivalent alternatives for path sources.
- \`lib/shared/neo4j/driver.rb\` impl-detection comment updated to reference the per-gem option, not the (overstated) "pins gemspec discovery" workaround.

## Out of scope
The CI does not yet exercise the MRI-on-JRuby flavor; we deferred that in #283. With this Bundler option known to work, adding such a row is realistic later.