### PR TITLE
Enable MRI flavor on JRuby (local + CI + production)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -81,10 +81,13 @@ file. Review the diff and commit.
 
 ## Switching between MRI and JRuby
 
-The container has both. MRI is on `$PATH` by default. Three useful modes:
+The container has both Rubies installed. The default shell uses MRI;
+no setup needed for the standard MRI-flavor-on-MRI path. To exercise
+the other two flavor combinations, run inside a subshell so PATH
+changes don't leak back:
 
-**JRuby flavor on JRuby** (the native cross-flavor case; will work
-once `lib/jruby/` has code):
+**JRuby flavor on JRuby** (the native JRuby path; will work once
+`lib/jruby/` has code):
 
 ```bash
 (
@@ -94,7 +97,7 @@ once `lib/jruby/` has code):
 )
 ```
 
-**MRI flavor on JRuby** (run the MRI codebase under the JVM):
+**MRI flavor on JRuby** (run the pure-Ruby codebase under the JVM):
 
 ```bash
 (
@@ -105,8 +108,7 @@ once `lib/jruby/` has code):
 )
 ```
 
-The parentheses create a subshell; env changes don't leak back. CI
-exercises both these modes via matrix rows.
+CI exercises all three combinations via matrix rows.
 
 `Gem.loaded_specs['neo4j-ruby-driver'].metadata['impl']` reports the
 active flavor — see `lib/shared/neo4j/driver.rb`.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -81,8 +81,10 @@ file. Review the diff and commit.
 
 ## Switching between MRI and JRuby
 
-The container has both. MRI is on `$PATH` by default. To exercise JRuby
-without polluting the current shell, run inside a subshell:
+The container has both. MRI is on `$PATH` by default. Three useful modes:
+
+**JRuby flavor on JRuby** (the native cross-flavor case; will work
+once `lib/jruby/` has code):
 
 ```bash
 (
@@ -92,10 +94,19 @@ without polluting the current shell, run inside a subshell:
 )
 ```
 
-The parentheses create a subshell; env changes don't leak back. To
-switch persistently within one shell, run those commands without the
-subshell wrapper, then open a new terminal when you want to go back to
-MRI (the codespace makes that one click in the terminal panel).
+**MRI flavor on JRuby** (run the MRI codebase under the JVM):
+
+```bash
+(
+  export PATH="$JRUBY_HOME/bin:$PATH"
+  export NEO4J_DRIVER_FORCE_MRI=1   # Gemfile pins the MRI gemspec
+  bundle install
+  bundle exec rspec
+)
+```
+
+The parentheses create a subshell; env changes don't leak back. CI
+exercises both these modes via matrix rows.
 
 `Gem.loaded_specs['neo4j-ruby-driver'].metadata['impl']` reports the
 active flavor — see `lib/shared/neo4j/driver.rb`.

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   rspec:
-    name: rspec (ruby ${{ matrix.ruby }} / neo4j ${{ matrix.neo4j }})
+    name: rspec (ruby ${{ matrix.ruby }}${{ matrix.force_mri && ' [mri flavor]' || '' }} / neo4j ${{ matrix.neo4j }})
     runs-on: ubuntu-latest
-    # JRuby implementation is not yet imported (lib/jruby/ is empty);
-    # let those rows fail without blocking the matrix until the JRuby
-    # code lands.
+    # JRuby rows are continue-on-error for now: native JRuby flavor has
+    # no code yet (lib/jruby/ empty), and the MRI-on-JRuby include row
+    # below is exercised here for the first time.
     continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
 
     strategy:
@@ -25,6 +25,16 @@ jobs:
           - "4.4.48-enterprise"
           - "5.26.25-enterprise"
           - "2026.04.0-enterprise"
+        # Default value so the `include` below adds a new row rather
+        # than merging into existing combinations (GH Actions semantics).
+        force_mri: [false]
+        include:
+          # MRI flavor on JRuby — exercises the cross-flavor path via
+          # NEO4J_DRIVER_FORCE_MRI=1 (the Gemfile's `gemspec name:` flip).
+          # Single Neo4j version to keep CI minutes reasonable.
+          - ruby: "jruby-10.1.0.0"
+            neo4j: "5.26.25-enterprise"
+            force_mri: true
 
     services:
       neo4j:
@@ -46,6 +56,9 @@ jobs:
       TEST_NEO4J_URL: bolt://localhost:7687
       TEST_NEO4J_USER: neo4j
       TEST_NEO4J_PASS: password
+      # Empty string when force_mri is false; '1' on the include row.
+      # The Gemfile checks this and pins to the MRI gemspec when set.
+      NEO4J_DRIVER_FORCE_MRI: ${{ matrix.force_mri && '1' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/testkit-stub.yml
+++ b/.github/workflows/testkit-stub.yml
@@ -7,10 +7,11 @@ on:
 
 jobs:
   testkit-stub:
-    name: testkit-stub (ruby ${{ matrix.ruby }})
+    name: testkit-stub (ruby ${{ matrix.ruby }}${{ matrix.force_mri && ' [mri flavor]' || '' }})
     runs-on: ubuntu-latest
-    # JRuby implementation isn't imported yet; matrix runs but does
-    # not block until lib/jruby/ has code.
+    # JRuby rows are continue-on-error: native JRuby flavor has no code
+    # yet (lib/jruby/ empty), and the MRI-on-JRuby include row below is
+    # exercised here for the first time.
     continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
 
     strategy:
@@ -19,12 +20,19 @@ jobs:
         ruby:
           - "3.4"
           - "jruby-10.1.0.0"
+        force_mri: [false]
+        include:
+          - ruby: "jruby-10.1.0.0"
+            force_mri: true
 
     env:
       TEST_DRIVER_NAME: ruby
       TESTKIT_PATH: ${{ github.workspace }}/../testkit
       # Per-impl baseline: MRI and JRuby progress independently.
-      BASELINE: ${{ github.workspace }}/.github/testkit-stub-baseline-${{ startsWith(matrix.ruby, 'jruby') && 'jruby' || 'mri' }}.txt
+      # The MRI-on-JRuby flavor uses the MRI baseline since it runs MRI code.
+      BASELINE: ${{ github.workspace }}/.github/testkit-stub-baseline-${{ (startsWith(matrix.ruby, 'jruby') && !matrix.force_mri) && 'jruby' || 'mri' }}.txt
+      # Empty string when force_mri is false; '1' on the include row.
+      NEO4J_DRIVER_FORCE_MRI: ${{ matrix.force_mri && '1' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -7,10 +7,11 @@ on:
 
 jobs:
   testkit:
-    name: testkit (ruby ${{ matrix.ruby }})
+    name: testkit (ruby ${{ matrix.ruby }}${{ matrix.force_mri && ' [mri flavor]' || '' }})
     runs-on: ubuntu-latest
-    # JRuby implementation isn't imported yet; matrix runs but does
-    # not block until lib/jruby/ has code.
+    # JRuby rows are continue-on-error: native JRuby flavor has no code
+    # yet (lib/jruby/ empty), and the MRI-on-JRuby include row below is
+    # exercised here for the first time.
     continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
 
     strategy:
@@ -19,6 +20,12 @@ jobs:
         ruby:
           - "3.4"
           - "jruby-10.1.0.0"
+        force_mri: [false]
+        include:
+          # MRI flavor on JRuby — NEO4J_DRIVER_FORCE_MRI=1 flips the
+          # Gemfile's `gemspec` directive to pin the MRI gemspec.
+          - ruby: "jruby-10.1.0.0"
+            force_mri: true
 
     services:
       neo4j:
@@ -47,7 +54,10 @@ jobs:
       TEST_NEO4J_VERSION: '5.26'
       TESTKIT_PATH: ${{ github.workspace }}/../testkit
       # Per-impl baseline: MRI and JRuby progress independently.
-      BASELINE: ${{ github.workspace }}/.github/testkit-baseline-${{ startsWith(matrix.ruby, 'jruby') && 'jruby' || 'mri' }}.txt
+      # The MRI-on-JRuby flavor uses the MRI baseline since it runs MRI code.
+      BASELINE: ${{ github.workspace }}/.github/testkit-baseline-${{ (startsWith(matrix.ruby, 'jruby') && !matrix.force_mri) && 'jruby' || 'mri' }}.txt
+      # Empty string when force_mri is false; '1' on the include row.
+      NEO4J_DRIVER_FORCE_MRI: ${{ matrix.force_mri && '1' || '' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,17 @@
 
 source 'https://rubygems.org'
 
-gemspec
+# Default: `gemspec` picks the platform-matching gemspec (MRI on cruby,
+# JRuby on java). `NEO4J_DRIVER_FORCE_MRI=1` pins to the MRI gemspec
+# regardless of host — used to develop / CI-test the MRI codebase under
+# JRuby. (Production consumers use `gem 'neo4j-ruby-driver',
+# force_ruby_platform: true` instead; that DSL option exists on `gem`
+# but not on `gemspec`, hence the env-var bridge here.)
+if ENV['NEO4J_DRIVER_FORCE_MRI'] == '1'
+  gemspec name: 'neo4j-ruby-driver'
+else
+  gemspec
+end
 
 group :development, :test do
   gem 'rspec', '~> 3.12'

--- a/JRUBY.md
+++ b/JRUBY.md
@@ -147,36 +147,57 @@ chosen impl and branches on `STAGED_BUILD`:
   a `path:` source.
 - Staged: files = flat `lib/**/*`, `require_paths = ['lib']`.
 
-### Selecting a flavor from source
+### Selecting a flavor
 
-Consumer Gemfile (path or git source):
+Default consumer Gemfile (any source):
 
 ```ruby
-gem 'neo4j-ruby-driver', path: '../neo4j-ruby-driver'
+gem 'neo4j-ruby-driver'
+# or path: '../neo4j-ruby-driver', or git: '...'
 ```
 
-Bundler scans `*.gemspec` in the source and picks the platform-compatible
-one — ruby on MRI, java on JRuby. The loader reads `spec.metadata['impl']`
-from whichever gemspec was selected, so it stays in sync automatically.
+Bundler picks the platform-compatible gemspec — ruby on MRI, java on
+JRuby. The loader reads `spec.metadata['impl']` from whichever gemspec
+was selected, so it stays in sync automatically.
 
-To force the MRI flavor on JRuby (e.g. to develop the MRI codebase
-under JRuby), pin gemspec discovery to the MRI file via `:glob`:
+To force the MRI flavor on JRuby (e.g. to opt out of the Java-driver
+delegation, or to develop the MRI codebase under JRuby), use Bundler's
+per-gem `force_ruby_platform: true`:
+
+```ruby
+gem 'neo4j-ruby-driver', force_ruby_platform: true
+```
+
+This works for any source (rubygems, path, git) and scopes to *this*
+gem only — Bundler still resolves other deps to their native platform
+variants. The global `bundle config force_ruby_platform true` does the
+same thing repo-wide and would break deps with JRuby-native code (e.g.
+`json`'s java variant).
+
+For path sources with both gemspecs visible, `:glob` works equivalently
+by hiding the java gemspec from discovery:
 
 ```ruby
 gem 'neo4j-ruby-driver', path: '../neo4j-ruby-driver',
                          glob: 'neo4j-ruby-driver.gemspec'
 ```
 
-The dev tree's own Gemfile uses the `gemspec` directive instead of
-`gem`; the equivalent override is `gemspec name: 'neo4j-ruby-driver'`.
+The dev tree's own `Gemfile` uses the `gemspec` directive instead of
+`gem`. The `gemspec` directive accepts `:name`/`:glob` but not
+`force_ruby_platform`, so we use an env-var bridge:
 
-For RubyGems-installed gems there is no clean per-gem override —
-`bundle config set --local force_ruby_platform true` exists but
-applies globally and breaks any other dependency that ships
-JRuby-native variants (e.g. activesupport's transitive `json` dep).
-This is a Bundler limitation, not specific to our gem. In practice,
-the cross-flavor case is a development concern and the path/git
-override above covers it.
+```ruby
+# Gemfile
+if ENV['NEO4J_DRIVER_FORCE_MRI'] == '1'
+  gemspec name: 'neo4j-ruby-driver'   # pin MRI gemspec
+else
+  gemspec                              # platform-based selection
+end
+```
+
+`NEO4J_DRIVER_FORCE_MRI=1 bundle install` on a JRuby host then runs
+the MRI flavor. CI exercises this via an extra matrix row in
+`.github/workflows/{specs,testkit,testkit-stub}.yml`.
 
 ### What the user sees after install
 

--- a/lib/shared/neo4j/driver.rb
+++ b/lib/shared/neo4j/driver.rb
@@ -14,13 +14,19 @@ module Neo4j
     # Picked from the gemspec Bundler/RubyGems actually selected, via
     # spec.metadata['impl']. Stays correct when the user opts into the
     # MRI flavor on JRuby (e.g. `gem 'neo4j-ruby-driver',
-    # force_ruby_platform: true` in their Gemfile), where RUBY_PLATFORM
-    # and the loaded gem disagree. Falls back to RUBY_PLATFORM when the
-    # spec isn't visible (raw source tree without RubyGems activation).
+    # force_ruby_platform: true` in their Gemfile), where the host Ruby
+    # and the loaded gem disagree.
+    #
+    # No RUBY_PLATFORM fallback: the cross-flavor mode makes
+    # RUBY_PLATFORM == 'java' a misleading proxy for "JRuby flavor"
+    # (it tells you the host, not the gem). When the spec metadata
+    # isn't visible (raw source-tree without RubyGems activation),
+    # default to :mri — that's the established flavor; consumers
+    # wanting the JRuby flavor without Bundler need to load the gem
+    # through Bundler/RubyGems so the metadata bridge works.
     def self.implementation
       declared = Gem.loaded_specs['neo4j-ruby-driver']&.metadata&.fetch('impl', nil)
-      return declared.to_sym if declared
-      (RUBY_PLATFORM == 'java') ? :jruby : :mri
+      declared&.to_sym || :mri
     end
   end
 end

--- a/lib/shared/neo4j/driver.rb
+++ b/lib/shared/neo4j/driver.rb
@@ -12,11 +12,11 @@ require 'zeitwerk'
 module Neo4j
   module Driver
     # Picked from the gemspec Bundler/RubyGems actually selected, via
-    # spec.metadata['impl']. Stays correct when the user pins gemspec
-    # discovery (e.g. `glob: 'neo4j-ruby-driver.gemspec'` from a JRuby
-    # host to develop the MRI flavor), where RUBY_PLATFORM and the
-    # loaded gem disagree. Falls back to RUBY_PLATFORM when the spec
-    # isn't visible (raw source tree without RubyGems activation).
+    # spec.metadata['impl']. Stays correct when the user opts into the
+    # MRI flavor on JRuby (e.g. `gem 'neo4j-ruby-driver',
+    # force_ruby_platform: true` in their Gemfile), where RUBY_PLATFORM
+    # and the loaded gem disagree. Falls back to RUBY_PLATFORM when the
+    # spec isn't visible (raw source tree without RubyGems activation).
     def self.implementation
       declared = Gem.loaded_specs['neo4j-ruby-driver']&.metadata&.fetch('impl', nil)
       return declared.to_sym if declared


### PR DESCRIPTION
## Summary
Now that we've verified Bundler accepts per-gem \`force_ruby_platform: true\` on \`gem\` lines (not just the global config), this PR wires the cross-flavor capability end-to-end.

| Context | Mechanism |
|---|---|
| **Production** consumer on JRuby | Already works. Their Gemfile: \`gem 'neo4j-ruby-driver', force_ruby_platform: true\`. Bundler picks our ruby-platform gem; loader reads \`metadata['impl']='mri'\`; MRI code runs. Documented. |
| **Local dev** on JRuby host | The \`gemspec\` directive accepts \`:name\`/\`:glob\` but **not** \`force_ruby_platform\`, so the project's Gemfile uses an env-var bridge: \`NEO4J_DRIVER_FORCE_MRI=1 bundle install\` pins the MRI gemspec. Default behaviour unchanged. |
| **CI** | New include row in all three workflows that sets \`NEO4J_DRIVER_FORCE_MRI=1\` on jruby-10.1.0.0; job-name suffix \`[mri flavor]\` for distinguishability. |

## Pieces

### Gemfile (env-var-driven gemspec selection)

\`\`\`ruby
if ENV['NEO4J_DRIVER_FORCE_MRI'] == '1'
  gemspec name: 'neo4j-ruby-driver'
else
  gemspec
end
\`\`\`

### CI matrix (specs / testkit / testkit-stub)

Adds \`force_mri: [false]\` as a matrix dimension so the \`include\` row with \`force_mri: true\` creates a new combination instead of merging into existing ones (GH Actions semantics — same trick we used for the per-impl baseline split in #282).

\`\`\`yaml
matrix:
  ruby: [..., "jruby-10.1.0.0"]
  force_mri: [false]
  include:
    - ruby: "jruby-10.1.0.0"
      force_mri: true
\`\`\`

The MRI-on-JRuby row uses the **MRI** testkit baseline (it runs MRI code), via:
\`\`\`yaml
BASELINE: .../testkit-baseline-${{ (startsWith(matrix.ruby, 'jruby') && !matrix.force_mri) && 'jruby' || 'mri' }}.txt
\`\`\`

continue-on-error stays for any jruby-* row, including this one, until we see what passes; promote later.

### Docs corrected

JRUBY.md previously claimed RubyGems sources had no clean per-gem override — wrong. Updated section "Selecting a flavor" to lead with \`force_ruby_platform: true\`. Loader comment in \`lib/shared/neo4j/driver.rb\` updated to match. \`.devcontainer/README.md\` "Switching" section now shows both cross-flavor modes (JRuby-on-JRuby and MRI-on-JRuby).

**Supersedes #288** — that was a doc-only version of the correction; this PR includes the same fix plus the implementation. Will close #288 on merge.

## Verified locally
- \`bundle install\` (default) → picks \`neo4j-ruby-driver.gemspec\` (ruby platform), \`metadata['impl']='mri'\`.
- \`NEO4J_DRIVER_FORCE_MRI=1 bundle install\` (on MRI host) → still picks MRI gemspec by name (default convergent — exercises the conditional).
- \`bundle exec rspec\` → 400 examples, 0 failures.
- All three workflow YAMLs parse; matrix shape correct (force_mri dim + 1 include row each).

## Test plan
- [ ] CI green on default MRI rows (3.4, 4.0).
- [ ] CI red-but-not-blocking on jruby-10.1 native row (lib/jruby/ empty — expected).
- [ ] CI on the new \`[mri flavor]\` row: shows what passes/fails. If specs are mostly green, follow-up PR can promote it out of continue-on-error.