### PR TITLE
Fix MRI-on-JRuby override: pass glob: alongside name: in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,12 @@ source 'https://rubygems.org'
 # force_ruby_platform: true` instead; that DSL option exists on `gem`
 # but not on `gemspec`, hence the env-var bridge here.)
 if ENV['NEO4J_DRIVER_FORCE_MRI'] == '1'
-  gemspec name: 'neo4j-ruby-driver'
+  # Both `name:` and `glob:` are required: `name:` narrows the initial
+  # gemspec lookup, but `gemspec` forwards to an implicit path source
+  # whose default glob (`{,*,*/*}.gemspec`) would otherwise re-discover
+  # neo4j-ruby-driver-java.gemspec — and Bundler's resolver would then
+  # pick the java variant on a JRuby host, defeating the override.
+  gemspec name: 'neo4j-ruby-driver', glob: 'neo4j-ruby-driver.gemspec'
 else
   gemspec
 end


### PR DESCRIPTION
## Summary
Follow-up to #289. The CI run that came in right after merge showed the new \`[mri flavor]\` matrix row STILL failing — lockfile had \`neo4j-ruby-driver-0.1.0-java\` despite \`NEO4J_DRIVER_FORCE_MRI=1\` being set.

## Root cause
Bundler's \`gemspec name: 'neo4j-ruby-driver'\` only narrows the **initial** gemspec discovery glob. It then forwards to an implicit path source whose own glob defaults to \`{,*,*/*}.gemspec\` — which re-discovers \`neo4j-ruby-driver-java.gemspec\` regardless. With both gemspecs visible at the path-source layer, the resolver picks the java variant on a JRuby host (more specific platform match). The override silently dies at the path-source layer.

Result on the failing run (job 74704069439):
- env shows \`NEO4J_DRIVER_FORCE_MRI: 1\` ✓
- but \`bundle lock\` writes \`neo4j-ruby-driver (0.1.0-java)\` ✗
- loader reads \`metadata['impl']='jruby'\`, lib/jruby/ is empty
- \`NameError: uninitialized constant Neo4j::Driver::AuthTokens\`

## Fix
Pass \`glob:\` explicitly so the path source also only sees the MRI gemspec:

\`\`\`ruby
gemspec name: 'neo4j-ruby-driver', glob: 'neo4j-ruby-driver.gemspec'
\`\`\`

Comment in the Gemfile explains the trap.

## Verified locally
- Default \`bundle install\`: picks ruby gemspec, \`metadata['impl']='mri'\` ✓
- \`NEO4J_DRIVER_FORCE_MRI=1 bundle install\`: also picks ruby gemspec, \`metadata['impl']='mri'\` ✓ (convergent on MRI; the divergence is only visible on a JRuby host)
- \`bundle exec rspec\`: 400 examples, 0 failures ✓

The CI matrix on this branch will exercise the JRuby path; expect the \`[mri flavor]\` row to either pass cleanly or fail for genuine reasons (MRI code surfacing JRuby-incompatible assumptions) rather than the loader-misroute we just fixed.