### PR TITLE
Restore the 20 testkit request handlers missing since the backend rewrite

### DIFF
--- a/testkit-backend/requests/auth_token_manager_close.rb
+++ b/testkit-backend/requests/auth_token_manager_close.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # Stub; see NewAuthTokenManager.
+    class AuthTokenManagerClose < Request
+      def process
+        delete(id)
+        named_entity('AuthTokenManager', id: id)
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/auth_token_manager_get_auth_completed.rb
+++ b/testkit-backend/requests/auth_token_manager_get_auth_completed.rb
@@ -6,8 +6,8 @@ module TestkitBackend
     # completion. Stub for parity with the Java backend.
     class AuthTokenManagerGetAuthCompleted < Request
       def process
-        raise NotImplementedError,
-              'AuthTokenManager callbacks are not implemented (driver does not advertise Feature:Auth:Managed)'
+        named_entity('BackendError',
+                     msg: 'AuthTokenManager callbacks are not implemented (driver does not advertise Feature:Auth:Managed)')
       end
     end
   end

--- a/testkit-backend/requests/auth_token_manager_get_auth_completed.rb
+++ b/testkit-backend/requests/auth_token_manager_get_auth_completed.rb
@@ -1,0 +1,14 @@
+module TestkitBackend
+  module Requests
+    # Frontend response to a backend->frontend
+    # AuthTokenManagerGetAuthRequest. The Ruby driver never emits that
+    # request (no managed-auth path), so testkit shouldn't send the
+    # completion. Stub for parity with the Java backend.
+    class AuthTokenManagerGetAuthCompleted < Request
+      def process
+        raise NotImplementedError,
+              'AuthTokenManager callbacks are not implemented (driver does not advertise Feature:Auth:Managed)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/auth_token_manager_handle_security_exception_completed.rb
+++ b/testkit-backend/requests/auth_token_manager_handle_security_exception_completed.rb
@@ -3,8 +3,8 @@ module TestkitBackend
     # See AuthTokenManagerGetAuthCompleted.
     class AuthTokenManagerHandleSecurityExceptionCompleted < Request
       def process
-        raise NotImplementedError,
-              'AuthTokenManager callbacks are not implemented (driver does not advertise Feature:Auth:Managed)'
+        named_entity('BackendError',
+                     msg: 'AuthTokenManager callbacks are not implemented (driver does not advertise Feature:Auth:Managed)')
       end
     end
   end

--- a/testkit-backend/requests/auth_token_manager_handle_security_exception_completed.rb
+++ b/testkit-backend/requests/auth_token_manager_handle_security_exception_completed.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # See AuthTokenManagerGetAuthCompleted.
+    class AuthTokenManagerHandleSecurityExceptionCompleted < Request
+      def process
+        raise NotImplementedError,
+              'AuthTokenManager callbacks are not implemented (driver does not advertise Feature:Auth:Managed)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/basic_auth_token_provider_completed.rb
+++ b/testkit-backend/requests/basic_auth_token_provider_completed.rb
@@ -3,8 +3,8 @@ module TestkitBackend
     # See AuthTokenManagerGetAuthCompleted.
     class BasicAuthTokenProviderCompleted < Request
       def process
-        raise NotImplementedError,
-              'BasicAuthTokenProvider callbacks are not implemented (driver does not advertise Feature:Auth:Managed)'
+        named_entity('BackendError',
+                     msg: 'BasicAuthTokenProvider callbacks are not implemented (driver does not advertise Feature:Auth:Managed)')
       end
     end
   end

--- a/testkit-backend/requests/basic_auth_token_provider_completed.rb
+++ b/testkit-backend/requests/basic_auth_token_provider_completed.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # See AuthTokenManagerGetAuthCompleted.
+    class BasicAuthTokenProviderCompleted < Request
+      def process
+        raise NotImplementedError,
+              'BasicAuthTokenProvider callbacks are not implemented (driver does not advertise Feature:Auth:Managed)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/bearer_auth_token_provider_completed.rb
+++ b/testkit-backend/requests/bearer_auth_token_provider_completed.rb
@@ -3,8 +3,8 @@ module TestkitBackend
     # See AuthTokenManagerGetAuthCompleted.
     class BearerAuthTokenProviderCompleted < Request
       def process
-        raise NotImplementedError,
-              'BearerAuthTokenProvider callbacks are not implemented (driver does not advertise Feature:Auth:Managed)'
+        named_entity('BackendError',
+                     msg: 'BearerAuthTokenProvider callbacks are not implemented (driver does not advertise Feature:Auth:Managed)')
       end
     end
   end

--- a/testkit-backend/requests/bearer_auth_token_provider_completed.rb
+++ b/testkit-backend/requests/bearer_auth_token_provider_completed.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # See AuthTokenManagerGetAuthCompleted.
+    class BearerAuthTokenProviderCompleted < Request
+      def process
+        raise NotImplementedError,
+              'BearerAuthTokenProvider callbacks are not implemented (driver does not advertise Feature:Auth:Managed)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/bookmark_manager_close.rb
+++ b/testkit-backend/requests/bookmark_manager_close.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # Stub; see NewBookmarkManager.
+    class BookmarkManagerClose < Request
+      def process
+        delete(id)
+        named_entity('BookmarkManager', id: id)
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/bookmarks_consumer_completed.rb
+++ b/testkit-backend/requests/bookmarks_consumer_completed.rb
@@ -1,0 +1,12 @@
+module TestkitBackend
+  module Requests
+    # Frontend response to a backend->frontend
+    # BookmarksConsumerRequest. We never emit one. Stub for parity.
+    class BookmarksConsumerCompleted < Request
+      def process
+        raise NotImplementedError,
+              'BookmarkManager callbacks are not implemented (driver does not advertise Feature:API:BookmarkManager)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/bookmarks_consumer_completed.rb
+++ b/testkit-backend/requests/bookmarks_consumer_completed.rb
@@ -4,8 +4,8 @@ module TestkitBackend
     # BookmarksConsumerRequest. We never emit one. Stub for parity.
     class BookmarksConsumerCompleted < Request
       def process
-        raise NotImplementedError,
-              'BookmarkManager callbacks are not implemented (driver does not advertise Feature:API:BookmarkManager)'
+        named_entity('BackendError',
+                     msg: 'BookmarkManager callbacks are not implemented (driver does not advertise Feature:API:BookmarkManager)')
       end
     end
   end

--- a/testkit-backend/requests/bookmarks_supplier_completed.rb
+++ b/testkit-backend/requests/bookmarks_supplier_completed.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # See BookmarksConsumerCompleted.
+    class BookmarksSupplierCompleted < Request
+      def process
+        raise NotImplementedError,
+              'BookmarkManager callbacks are not implemented (driver does not advertise Feature:API:BookmarkManager)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/bookmarks_supplier_completed.rb
+++ b/testkit-backend/requests/bookmarks_supplier_completed.rb
@@ -3,8 +3,8 @@ module TestkitBackend
     # See BookmarksConsumerCompleted.
     class BookmarksSupplierCompleted < Request
       def process
-        raise NotImplementedError,
-              'BookmarkManager callbacks are not implemented (driver does not advertise Feature:API:BookmarkManager)'
+        named_entity('BackendError',
+                     msg: 'BookmarkManager callbacks are not implemented (driver does not advertise Feature:API:BookmarkManager)')
       end
     end
   end

--- a/testkit-backend/requests/client_certificate_provider_close.rb
+++ b/testkit-backend/requests/client_certificate_provider_close.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # Stub; see NewClientCertificateProvider.
+    class ClientCertificateProviderClose < Request
+      def process
+        delete(id)
+        named_entity('ClientCertificateProvider', id: id)
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/client_certificate_provider_completed.rb
+++ b/testkit-backend/requests/client_certificate_provider_completed.rb
@@ -1,0 +1,12 @@
+module TestkitBackend
+  module Requests
+    # Frontend response to a backend->frontend ClientCertificate request.
+    # We never emit one. Stub for parity.
+    class ClientCertificateProviderCompleted < Request
+      def process
+        raise NotImplementedError,
+              'ClientCertificateProvider callbacks are not implemented (driver does not advertise Feature:API:SSLClientCertificate)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/client_certificate_provider_completed.rb
+++ b/testkit-backend/requests/client_certificate_provider_completed.rb
@@ -4,8 +4,8 @@ module TestkitBackend
     # We never emit one. Stub for parity.
     class ClientCertificateProviderCompleted < Request
       def process
-        raise NotImplementedError,
-              'ClientCertificateProvider callbacks are not implemented (driver does not advertise Feature:API:SSLClientCertificate)'
+        named_entity('BackendError',
+                     msg: 'ClientCertificateProvider callbacks are not implemented (driver does not advertise Feature:API:SSLClientCertificate)')
       end
     end
   end

--- a/testkit-backend/requests/cypher_type_field.rb
+++ b/testkit-backend/requests/cypher_type_field.rb
@@ -9,9 +9,9 @@ module TestkitBackend
     # rare and we don't currently advertise the relevant feature.
     class CypherTypeField < Request
       def process
-        raise NotImplementedError,
-              'CypherTypeField introspection is not implemented; ' \
-              'driver eager-converts cypher values to native Ruby types at hydration time.'
+        named_entity('BackendError',
+                     msg: 'CypherTypeField introspection is not implemented; ' \
+                          'driver eager-converts cypher values to native Ruby types at hydration time.')
       end
     end
   end

--- a/testkit-backend/requests/cypher_type_field.rb
+++ b/testkit-backend/requests/cypher_type_field.rb
@@ -1,0 +1,18 @@
+module TestkitBackend
+  module Requests
+    # Stub: introspects a single field of a typed cypher value.
+    # Java's TestkitCypherType[Mapper] decomposes things like a
+    # CypherDateTime into its parts on demand. The Ruby backend
+    # eager-converts cypher values to native Ruby (Date/Time/etc.) at
+    # hydration time, so we don't retain a typed-cypher object to
+    # introspect later. Tests that need field-level introspection are
+    # rare and we don't currently advertise the relevant feature.
+    class CypherTypeField < Request
+      def process
+        raise NotImplementedError,
+              'CypherTypeField introspection is not implemented; ' \
+              'driver eager-converts cypher values to native Ruby types at hydration time.'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/fake_time_install.rb
+++ b/testkit-backend/requests/fake_time_install.rb
@@ -1,0 +1,12 @@
+module TestkitBackend
+  module Requests
+    # Stub: the Ruby driver doesn't advertise Backend:MockTime, so
+    # testkit shouldn't drive these — but register for parity.
+    class FakeTimeInstall < Request
+      def process
+        raise NotImplementedError,
+              'FakeTime is not implemented (driver does not advertise Backend:MockTime)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/fake_time_install.rb
+++ b/testkit-backend/requests/fake_time_install.rb
@@ -4,8 +4,8 @@ module TestkitBackend
     # testkit shouldn't drive these — but register for parity.
     class FakeTimeInstall < Request
       def process
-        raise NotImplementedError,
-              'FakeTime is not implemented (driver does not advertise Backend:MockTime)'
+        named_entity('BackendError',
+                     msg: 'FakeTime is not implemented (driver does not advertise Backend:MockTime)')
       end
     end
   end

--- a/testkit-backend/requests/fake_time_tick.rb
+++ b/testkit-backend/requests/fake_time_tick.rb
@@ -3,8 +3,8 @@ module TestkitBackend
     # Stub; see FakeTimeInstall.
     class FakeTimeTick < Request
       def process
-        raise NotImplementedError,
-              'FakeTime is not implemented (driver does not advertise Backend:MockTime)'
+        named_entity('BackendError',
+                     msg: 'FakeTime is not implemented (driver does not advertise Backend:MockTime)')
       end
     end
   end

--- a/testkit-backend/requests/fake_time_tick.rb
+++ b/testkit-backend/requests/fake_time_tick.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # Stub; see FakeTimeInstall.
+    class FakeTimeTick < Request
+      def process
+        raise NotImplementedError,
+              'FakeTime is not implemented (driver does not advertise Backend:MockTime)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/fake_time_uninstall.rb
+++ b/testkit-backend/requests/fake_time_uninstall.rb
@@ -3,8 +3,8 @@ module TestkitBackend
     # Stub; see FakeTimeInstall.
     class FakeTimeUninstall < Request
       def process
-        raise NotImplementedError,
-              'FakeTime is not implemented (driver does not advertise Backend:MockTime)'
+        named_entity('BackendError',
+                     msg: 'FakeTime is not implemented (driver does not advertise Backend:MockTime)')
       end
     end
   end

--- a/testkit-backend/requests/fake_time_uninstall.rb
+++ b/testkit-backend/requests/fake_time_uninstall.rb
@@ -1,0 +1,11 @@
+module TestkitBackend
+  module Requests
+    # Stub; see FakeTimeInstall.
+    class FakeTimeUninstall < Request
+      def process
+        raise NotImplementedError,
+              'FakeTime is not implemented (driver does not advertise Backend:MockTime)'
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/new_auth_token_manager.rb
+++ b/testkit-backend/requests/new_auth_token_manager.rb
@@ -1,0 +1,17 @@
+module TestkitBackend
+  module Requests
+    # Stub: the Ruby driver doesn't advertise Feature:Auth:Managed, so
+    # testkit shouldn't drive these. We still register the request so
+    # an out-of-order call surfaces as a clean BackendError rather
+    # than "uninitialized constant Requests::NewAuthTokenManager".
+    class NewAuthTokenManager < Request
+      def process
+        reference('AuthTokenManager')
+      end
+
+      def to_object
+        Object.new
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/new_basic_auth_token_manager.rb
+++ b/testkit-backend/requests/new_basic_auth_token_manager.rb
@@ -1,0 +1,14 @@
+module TestkitBackend
+  module Requests
+    # Stub; see NewAuthTokenManager.
+    class NewBasicAuthTokenManager < Request
+      def process
+        reference('BasicAuthTokenManager')
+      end
+
+      def to_object
+        Object.new
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/new_bearer_auth_token_manager.rb
+++ b/testkit-backend/requests/new_bearer_auth_token_manager.rb
@@ -1,0 +1,14 @@
+module TestkitBackend
+  module Requests
+    # Stub; see NewAuthTokenManager.
+    class NewBearerAuthTokenManager < Request
+      def process
+        reference('BearerAuthTokenManager')
+      end
+
+      def to_object
+        Object.new
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/new_bookmark_manager.rb
+++ b/testkit-backend/requests/new_bookmark_manager.rb
@@ -1,0 +1,14 @@
+module TestkitBackend
+  module Requests
+    # Stub: the Ruby driver doesn't advertise Feature:API:BookmarkManager.
+    class NewBookmarkManager < Request
+      def process
+        reference('BookmarkManager')
+      end
+
+      def to_object
+        Object.new
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/new_client_certificate_provider.rb
+++ b/testkit-backend/requests/new_client_certificate_provider.rb
@@ -1,0 +1,14 @@
+module TestkitBackend
+  module Requests
+    # Stub: the Ruby driver doesn't advertise Feature:API:SSLClientCertificate.
+    class NewClientCertificateProvider < Request
+      def process
+        reference('ClientCertificateProvider')
+      end
+
+      def to_object
+        Object.new
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/start_sub_test.rb
+++ b/testkit-backend/requests/start_sub_test.rb
@@ -1,0 +1,70 @@
+module TestkitBackend
+  module Requests
+    # Mirrors Java testkit-backend StartSubTest.java. For tests that
+    # parametrise over time-zone ids or datetime fields the backend may
+    # skip individual subtests whose params can't be expressed in the
+    # local TZ database / can't round-trip through this VM's datetime
+    # type.
+    #
+    # testkit invokes us only for tests whose StartTest response was
+    # RunSubTests. We currently respond RunTest at StartTest, so this
+    # handler is exercised only when testkit explicitly asks per-
+    # subtest (rare), but it's wired anyway to mirror the Java backend.
+    class StartSubTest < Request
+      SKIP_CHECKERS = {
+        /\Aneo4j\.datatypes\.test_temporal_types\.TestDataTypes\.test_should_echo_all_timezone_ids\z/ =>
+          :check_date_time_supported,
+        /\Aneo4j\.datatypes\.test_temporal_types\.TestDataTypes\.test_date_time_cypher_created_tz_id\z/ =>
+          :check_tz_id_supported
+      }.freeze
+
+      def process
+        SKIP_CHECKERS.each do |pattern, checker|
+          next unless pattern.match?(test_name)
+
+          reason = send(checker, subtest_arguments || {})
+          return reason ? skip(reason) : run
+        end
+        run
+      end
+
+      private
+
+      # tzinfo (already a driver runtime dep) is the authoritative source
+      # for whether an IANA zone id is known. The check matches Java's
+      # ZoneId.getAvailableZoneIds().contains(tzId).
+      def check_tz_id_supported(params)
+        tz_id = params['tz_id']
+        TZInfo::Timezone.get(tz_id) && nil
+      rescue TZInfo::InvalidTimezoneIdentifier
+        "Timezone not supported: #{tz_id}"
+      end
+
+      # Mirror Java: try to construct a zoned datetime from the supplied
+      # params and verify the explicit utc_offset matches what tzinfo
+      # would derive for that instant. Skip if either step fails.
+      def check_date_time_supported(params)
+        data = params.dig('dt', 'data') or raise "param 'dt' expected to contain 'data'"
+        tz = TZInfo::Timezone.get(data['timezone_id'])
+        local = ::Time.new(data['year'], data['month'], data['day'],
+                           data['hour'], data['minute'],
+                           data['second'] + data['nanosecond'] / 1e9, 0)
+        derived_offset = tz.period_for_local(local, true).utc_total_offset
+        return nil if derived_offset == data['utc_offset_s']
+
+        "DateTime not supported: Unmatched UTC offset. TestKit expected " \
+        "#{data['utc_offset_s']}, local zone db yielded #{derived_offset}"
+      rescue TZInfo::InvalidTimezoneIdentifier, TZInfo::AmbiguousTime, TZInfo::PeriodNotFound, ArgumentError => e
+        "DateTime not supported: #{e.message}"
+      end
+
+      def run
+        named_entity('RunTest')
+      end
+
+      def skip(reason)
+        named_entity('SkipTest', reason: reason)
+      end
+    end
+  end
+end

--- a/testkit-backend/requests/start_sub_test.rb
+++ b/testkit-backend/requests/start_sub_test.rb
@@ -33,8 +33,13 @@ module TestkitBackend
       # tzinfo (already a driver runtime dep) is the authoritative source
       # for whether an IANA zone id is known. The check matches Java's
       # ZoneId.getAvailableZoneIds().contains(tzId).
+      #
+      # `params` is the value of the request's `subtestArguments` field.
+      # JSON.parse uses symbolize_names: true at the wire boundary and
+      # Request.from only underscores the top-level `data` keys, so
+      # nested hashes (this one) keep their original symbol keys.
       def check_tz_id_supported(params)
-        tz_id = params['tz_id']
+        tz_id = params[:tz_id]
         TZInfo::Timezone.get(tz_id) && nil
       rescue TZInfo::InvalidTimezoneIdentifier
         "Timezone not supported: #{tz_id}"
@@ -44,16 +49,16 @@ module TestkitBackend
       # params and verify the explicit utc_offset matches what tzinfo
       # would derive for that instant. Skip if either step fails.
       def check_date_time_supported(params)
-        data = params.dig('dt', 'data') or raise "param 'dt' expected to contain 'data'"
-        tz = TZInfo::Timezone.get(data['timezone_id'])
-        local = ::Time.new(data['year'], data['month'], data['day'],
-                           data['hour'], data['minute'],
-                           data['second'] + data['nanosecond'] / 1e9, 0)
+        data = params.dig(:dt, :data) or raise "param 'dt' expected to contain 'data'"
+        tz = TZInfo::Timezone.get(data[:timezone_id])
+        local = ::Time.new(data[:year], data[:month], data[:day],
+                           data[:hour], data[:minute],
+                           data[:second] + data[:nanosecond] / 1e9, 0)
         derived_offset = tz.period_for_local(local, true).utc_total_offset
-        return nil if derived_offset == data['utc_offset_s']
+        return nil if derived_offset == data[:utc_offset_s]
 
         "DateTime not supported: Unmatched UTC offset. TestKit expected " \
-        "#{data['utc_offset_s']}, local zone db yielded #{derived_offset}"
+        "#{data[:utc_offset_s]}, local zone db yielded #{derived_offset}"
       rescue TZInfo::InvalidTimezoneIdentifier, TZInfo::AmbiguousTime, TZInfo::PeriodNotFound, ArgumentError => e
         "DateTime not supported: #{e.message}"
       end


### PR DESCRIPTION
## Why

PR #294 ported the lean OpenStruct/NIO backend from the 6.x branch wholesale. That branch's backend predated several testkit features (managed auth, bookmark managers, client certificate providers, fake time, **subtest deciders**, typed cypher field introspection), and my "carry forward modern handlers" todo from that PR was marked done but never actually executed. Apologies — that was sloppy bookkeeping on my part.

Net effect today: testkit could send any of 20 request types and the dispatcher would error with `No handler for request <name>`. None should be reached because we don't advertise the gating features in `GetFeatures`, but their absence was a latent bug — a future test firing one before the feature check would have crashed the connection.

## What's in this PR

### Real implementation: **StartSubTest** (your specific ask)

Mirrors the Java `StartSubTest.java` per-subtest decider for the two temporal datatype tests:

- `neo4j.datatypes.test_temporal_types.TestDataTypes.test_should_echo_all_timezone_ids` → checks whether the wire `utc_offset_s` matches tzinfo's offset for the given `timezone_id` at that instant.
- `neo4j.datatypes.test_temporal_types.TestDataTypes.test_date_time_cypher_created_tz_id` → checks the tz_id is known to tzinfo.

Uses tzinfo (already a driver runtime dep).

### Lifecycle stubs — return reference / delete reference

`Object.new` placeholder since we don't advertise the gating feature:

- `NewAuthTokenManager`, `NewBasicAuthTokenManager`, `NewBearerAuthTokenManager`, `AuthTokenManagerClose`
- `NewBookmarkManager`, `BookmarkManagerClose`
- `NewClientCertificateProvider`, `ClientCertificateProviderClose`

### Completion callbacks — raise NotImplementedError

The driver never emits the corresponding backend→frontend request, so testkit shouldn't send the completion; if it does we surface a clean BackendError instead of a NameError:

- `AuthTokenManagerGetAuthCompleted`, `AuthTokenManagerHandleSecurityExceptionCompleted`
- `BasicAuthTokenProviderCompleted`, `BearerAuthTokenProviderCompleted`
- `BookmarksConsumerCompleted`, `BookmarksSupplierCompleted`
- `ClientCertificateProviderCompleted`

### Not implemented — raise NotImplementedError with explanation

- `CypherTypeField` — driver eager-converts cypher to native Ruby at hydration time; no typed-cypher object retained to introspect.
- `FakeTimeInstall` / `FakeTimeTick` / `FakeTimeUninstall` — driver doesn't advertise `Backend:MockTime`.

## Test plan

- [x] Backend boots without load errors
- [x] `bundle exec rspec` → 400/0
- [x] `tests.stub.basic_query.test_basic_query` → 6/6 OK
- [ ] testkit-stub + testkit baselines unchanged (regression gate should pass; no new advertised features so no new tests should activate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)