### PR TITLE
Slice 22: impersonation + execute_query feature completion

### DIFF
--- a/lib/mri/neo4j/driver/driver.rb
+++ b/lib/mri/neo4j/driver/driver.rb
@@ -97,28 +97,51 @@ module Neo4j
       # (keys, materialised records, summary). Convenience for "I just
       # want results, don't make me build a session".
       #
-      # `config`: :database (str), :routing (RoutingControl::READ/WRITE),
-      #   :impersonatedUser, :bookmarkManagerId, :txMeta, :timeout,
-      #   :authorizationToken.
-      # Honours :database and :routing today; ignores the rest until the
-      # corresponding driver features land (impersonation, bookmark
-      # manager, per-session auth, etc.).
-      def execute_query(cypher, params = {}, config = {})
+      # Signature mirrors the JRuby flavour (and Java's overload of
+      # `executeQuery(query, authToken, queryConfig, parameters)`) so
+      # cross-flavour callers — testkit and the published Ruby API —
+      # stay identical.
+      #
+      # `config` keys (Ruby snake_case throughout):
+      #   :database            — string, the database to target.
+      #   :routing             — RoutingControl::READ / ::WRITE.
+      #   :bookmark_manager    — BookmarkManager for cross-session
+      #                          causal consistency.
+      #   :impersonated_user   — server runs the query as if this user
+      #                          had issued it (Bolt 4.4+, requires
+      #                          impersonator privileges).
+      #   :metadata            — map echoed back in summary; used by
+      #                          query-log / monitoring tooling.
+      #   :timeout             — seconds (or ActiveSupport::Duration);
+      #                          server-side transaction timeout.
+      # `auth_token` is accepted positionally for parity with the
+      # JRuby surface but not yet honoured — per-call auth is its own
+      # slice (Bolt 5.1+ LOGOFF/LOGON).
+      def execute_query(cypher, auth_token = nil, config = {}, **params)
         routing = config[:routing] || config['routing'] || RoutingControl::WRITE
         database = config[:database] || config['database']
 
         session_opts = {
           database: database,
-          default_access_mode: routing
+          default_access_mode: routing,
+          bookmark_manager: config[:bookmark_manager],
+          impersonated_user: config[:impersonated_user]
+        }.compact
+
+        # Forwarded to the managed-tx call below — the BEGIN extras
+        # honour metadata/timeout per-tx, not session-wide.
+        tx_kwargs = {
+          metadata: config[:metadata],
+          timeout: config[:timeout]
         }.compact
 
         keys = nil
         records = nil
         summary = nil
 
-        session(session_opts) do |s|
+        session(**session_opts) do |s|
           method = routing == RoutingControl::READ ? :execute_read : :execute_write
-          s.send(method) do |tx|
+          s.send(method, **tx_kwargs) do |tx|
             result = tx.run(cypher, **params)
             records = result.to_a
             keys = result.keys

--- a/lib/mri/neo4j/driver/session.rb
+++ b/lib/mri/neo4j/driver/session.rb
@@ -49,11 +49,15 @@ module Neo4j
         # `bookmarks` is the current bookmark snapshot so server-side
         # causal consistency works across auto-commit runs without an
         # explicit transaction.
+        # `imp_user` (Bolt 4.4+) makes the server run the query as if
+        # the named user had issued it — auth as the session's user,
+        # authz as the impersonated one.
         run_extra = {
           db: @options[:database],
           mode: (session_access_mode == :read ? 'r' : nil),
           tx_timeout: timeout_to_milliseconds(timeout),
           tx_metadata:,
+          imp_user: @options[:impersonated_user],
           bookmarks: current_bookmarks_for_extra
         }
         run_extra.reject!(&Internal::Extras::BLANK)

--- a/lib/mri/neo4j/driver/transaction.rb
+++ b/lib/mri/neo4j/driver/transaction.rb
@@ -26,7 +26,8 @@ module Neo4j
           db: options[:database],
           mode: options[:access_mode],
           tx_timeout: options[:timeout],
-          tx_metadata: options[:metadata]
+          tx_metadata: options[:metadata],
+          imp_user: options[:impersonated_user]
         }
         begin_extra.reject!(&Internal::Extras::BLANK)
 

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -95,7 +95,7 @@ module TestkitBackend
         'Feature:API:Type.Vector'                           => '',
 
         # --- Other features --------------------------------------------------
-        'Feature:Impersonation'                             => 'ja',
+        'Feature:Impersonation'                             => 'jar',
         'Feature:IdempotentRetries'                         => '',
 
         # --- Optimizations ---------------------------------------------------


### PR DESCRIPTION
## Why

Two longstanding gaps in one slice:

- **Impersonation** — the Bolt 4.4+ \`imp_user\` extra is already used in our ROUTE message but was never plumbed into BEGIN/RUN. \`Feature:Impersonation\` was \`'ja'\` (JRuby-only).
- **\`Driver#execute_query\`** — MRI used \`(cypher, params, config)\` while the JRuby flavour (and the testkit-backend) call it as \`(query, auth_token, config, **parameters)\`. Every example in \`execute_query_spec.rb\` failed against a Neo4j 5+ server with \`ArgumentError: wrong number of arguments\` — but the spec is gated by \`version: '>=5'\`, so the bug was hidden whenever CI used 4.4.

## What's in

- **\`Session#run\`** auto-commit RUN extras now include \`imp_user: @options[:impersonated_user]\` (dropped by the BLANK filter when nil — testkit stub scripts compare against omission).
- **\`Transaction#initialize\`** BEGIN extras add \`imp_user: options[:impersonated_user]\` the same way; covers \`session.begin_transaction\`, \`execute_read\`, \`execute_write\`.
- **\`Driver#execute_query\`** signature aligned with the JRuby surface (\`query, auth_token = nil, config = {}, **parameters\`). The single testkit-backend \`execute_query.rb\` shape now works on both flavours unchanged.
- \`:impersonated_user\` / \`:metadata\` / \`:timeout\` forwarded from \`config\` into session_opts and the managed-tx kwargs.
- Pre-existing bug fixed: \`session(session_opts)\` (positional hash) → \`session(**session_opts)\` (kwargs).
- \`auth_token\` accepted positionally for parity with JRuby but not yet honoured — per-call session auth is its own slice (Bolt 5.1+ LOGOFF/LOGON).
- Docstring rewritten to list the actually-honoured keys, in snake_case throughout.
- **GetFeatures**: \`Feature:Impersonation\` flips \`'ja'\` → \`'jar'\`.

## Test plan

- [x] Local Neo4j 2026.04 smoke: \`session(impersonated_user: 'neo4j')\` and \`execute_query(..., impersonated_user: 'neo4j')\` both succeed — confirming the field reaches the wire.
- [x] \`spec/shared/neo4j/driver/execute_query_spec.rb\` — 16 examples, 0 failures (was 16 failures with the old signature).
- [x] Full suite: \`spec/shared/neo4j/driver\` + \`spec/mri\` (232 / 0), \`spec/shared/integration\` (193 / 0).
- [ ] CI: rspec matrix + testkit + testkit-stub + testkit-tls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)