### PR TITLE
spec(session): address Copilot review comments from #323

### DIFF
--- a/spec/shared/integration/session_spec.rb
+++ b/spec/shared/integration/session_spec.rb
@@ -795,7 +795,7 @@ RSpec.describe 'Session' do
 
   # --- Ported from neo4j-java-driver SessionIT.java ---
 
-  it 'Allow To Consume Records Slowly And Close Session' do
+  it 'allows consuming records slowly and closing the session' do
     skip 'Ruby driver does not surface the pending stream error on session.close (Java does)'
     session = driver.session
     result = session.run('UNWIND range(10000, 0, -1) AS x RETURN 10 / x')
@@ -830,7 +830,10 @@ RSpec.describe 'Session' do
   it 'errors using session.run when database is absent', version: '>=4' do
     session = driver.session(database: 'foo')
     expect { session.run('RETURN 1').consume }
-      .to raise_error(Neo4j::Driver::Exceptions::ClientException, /Database does not exist.*foo/)
+      .to raise_error(Neo4j::Driver::Exceptions::ClientException) do |e|
+        expect(e.code).to eq 'Neo.ClientError.Database.DatabaseNotFound'
+        expect(e.message).to match(/Database does not exist.*foo/)
+      end
   ensure
     session&.close
   end
@@ -840,7 +843,10 @@ RSpec.describe 'Session' do
     expect do
       tx = session.begin_transaction
       tx.run('RETURN 1').consume
-    end.to raise_error(Neo4j::Driver::Exceptions::ClientException, /Database does not exist.*foo/)
+    end.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |e|
+      expect(e.code).to eq 'Neo.ClientError.Database.DatabaseNotFound'
+      expect(e.message).to match(/Database does not exist.*foo/)
+    end
   ensure
     session&.close
   end
@@ -848,7 +854,10 @@ RSpec.describe 'Session' do
   it 'errors using execute_read when database is absent', version: '>=4' do
     session = driver.session(database: 'foo')
     expect { session.execute_read { |tx| tx.run('RETURN 1').consume } }
-      .to raise_error(Neo4j::Driver::Exceptions::ClientException, /Database does not exist.*foo/)
+      .to raise_error(Neo4j::Driver::Exceptions::ClientException) do |e|
+        expect(e.code).to eq 'Neo.ClientError.Database.DatabaseNotFound'
+        expect(e.message).to match(/Database does not exist.*foo/)
+      end
   ensure
     session&.close
   end

--- a/spec/shared/integration/session_spec.rb
+++ b/spec/shared/integration/session_spec.rb
@@ -795,7 +795,7 @@ RSpec.describe 'Session' do
 
   # --- Ported from neo4j-java-driver SessionIT.java ---
 
-  it 'allows consuming records slowly and closing the session' do
+  it 'allows to consume records slowly and close session' do
     skip 'Ruby driver does not surface the pending stream error on session.close (Java does)'
     session = driver.session
     result = session.run('UNWIND range(10000, 0, -1) AS x RETURN 10 / x')


### PR DESCRIPTION
Small follow-up to #323 addressing two Copilot review comments:

- **Title-case description renamed** to lowercase (`allows consuming records slowly and closing the session`) to match the prevailing style of the other ported tests in the same block.
- **Stable error-code assertion added** for the three "database is absent" examples — `expect(e.code).to eq 'Neo.ClientError.Database.DatabaseNotFound'` (the Neo4j status code is stable across server versions / editions / locales). The message regex is kept as a softer fidelity guard against the Java original's `containsString("Database does not exist. Database name: 'foo'")`.

(The third Copilot point — that the explicit-transaction example doesn't close the tx on exception — wasn't actioned: the Java original at `SessionIT.java:1053` is annotated `@SuppressWarnings("resource")` for exactly that reason; it deliberately leaves the tx unclosed and relies on `session.close()` for teardown. Keeping parity with that.)

### Verification
7 examples (the original ports), 0 failures, 1 pending (the documented driver gap on stream-error-on-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error handling validation in session integration tests for database absence scenarios with more specific Neo4j error code assertions.
  * Improved consistency in test descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->