### PR TITLE
spec(driver-close): port from neo4j-java-driver DriverCloseIT

### DIFF
--- a/spec/shared/integration/driver_close_spec.rb
+++ b/spec/shared/integration/driver_close_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Ported from neo4j-java-driver DriverCloseIT.java.
+#
+# Cross-impl note: MRI raises Neo4j::Driver::Exceptions::ClientException
+# ('Driver is closed'); JRuby surfaces Java's IllegalStateException
+# ('This driver instance has already been closed' / 'Connection source
+# is closed.'). There is no common Ruby exception ancestor across both
+# impls today, so these specs assert on the *message* (regex) rather
+# than the class. Tightening to a class can happen once the JRuby ext
+# wraps these paths into Neo4j::Driver::Exceptions::*.
+RSpec.describe 'Driver#close' do
+  def new_driver
+    Neo4j::Driver::GraphDatabase.driver(uri, basic_auth_token)
+  end
+
+  it 'is idempotent — closing an already-closed driver does not raise' do
+    d = new_driver
+    expect { d.close; d.close; d.close }.not_to raise_error
+  end
+
+  it 'raises when calling session on a closed driver' do
+    d = new_driver
+    d.close
+    expect { d.session }.to raise_error(/closed/i)
+  end
+
+  it 'raises when calling session(default_access_mode:) on a closed driver' do
+    d = new_driver
+    d.close
+    expect { d.session(default_access_mode: Neo4j::Driver::AccessMode::WRITE) }.to raise_error(/closed/i)
+  end
+
+  it 'raises when using a session after the driver is closed' do
+    d = new_driver
+    session = d.session
+    d.close
+    expect { session.run('RETURN 1').consume }.to raise_error(/closed/i)
+  end
+end

--- a/spec/shared/integration/driver_close_spec.rb
+++ b/spec/shared/integration/driver_close_spec.rb
@@ -14,24 +14,24 @@ RSpec.describe 'Driver#close' do
     Neo4j::Driver::GraphDatabase.driver(uri, basic_auth_token)
   end
 
-  it 'is idempotent — closing an already-closed driver does not raise' do
+  it 'close closed driver' do
     d = new_driver
     expect { d.close; d.close; d.close }.not_to raise_error
   end
 
-  it 'raises when calling session on a closed driver' do
+  it 'session throws for closed driver' do
     d = new_driver
     d.close
     expect { d.session }.to raise_error(/closed/i)
   end
 
-  it 'raises when calling session(default_access_mode:) on a closed driver' do
+  it 'session with mode throws for closed driver' do
     d = new_driver
     d.close
     expect { d.session(default_access_mode: Neo4j::Driver::AccessMode::WRITE) }.to raise_error(/closed/i)
   end
 
-  it 'raises when using a session after the driver is closed' do
+  it 'use session after driver is closed' do
     d = new_driver
     session = d.session
     d.close


### PR DESCRIPTION
Sixth IT-port PR in the series. No prior `driver_close_spec` existed — creating one with 4 of 6 portable DriverCloseIT tests.

### Ported (4, all passing on JRuby locally)

| Java method | rspec |
|---|---|
| `closeClosedDriver` | `is idempotent — closing an already-closed driver does not raise` |
| `sessionThrowsForClosedDriver` | `raises when calling session on a closed driver` |
| `sessionWithModeThrowsForClosedDriver` | `raises when calling session(default_access_mode:) on a closed driver` |
| `useSessionAfterDriverIsClosed` | `raises when using a session after the driver is closed` |

### Not ported (with reasons)
- **`isEncryptedThrowsForClosedDriver`** — MRI's `Driver#encrypted?` is defined as `ENCRYPTED_SCHEMES.include?(@uri.scheme) || @options[:encrypted] == true` with **no `@closed` guard**, so it returns true/false rather than raising after close. Java/JRuby raise `IllegalStateException`. Skipped until MRI's behavior is aligned.
- **`shouldInterruptStreamConsumptionAndEndRetriesOnDriverClosure`** — requires `CompletableFuture`-style concurrent `driver.close` mid-tx with explicit `fetchSize` + interrupt semantics; inherently flaky and async-heavy.

### Cross-impl class divergence
- **MRI** raises `Neo4j::Driver::Exceptions::ClientException` (`"Driver is closed"`).
- **JRuby** surfaces either `Java::JavaLang::IllegalStateException` (`"This driver instance has already been closed"`) or `Neo4j::Driver::Exceptions::IllegalStateException` (`"Connection source is closed."`) depending on path.

There's no common Ruby ancestor across both impls today (JRuby leaks a raw Java exception on `driver.session`-after-close, which is arguably a JRuby ext gap). The specs therefore assert on **message regex** (`/closed/i`) — flexible enough to pass on both flavours. Once the JRuby ext wraps these paths into `Neo4j::Driver::Exceptions::*`, the assertions can tighten to a class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to verify proper driver closure behavior, including repeated closure operations and error handling for operations performed on closed drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->