### PR TITLE
feat(jruby): support max_connection_lifetime config → Feature:API:Driver:MaxConnectionLifetime

### DIFF
--- a/.github/testkit-stub-baseline-jruby.txt
+++ b/.github/testkit-stub-baseline-jruby.txt
@@ -922,4 +922,5 @@ Stub tests::test_tx_run_result_list_pulls_all_records_at_once_next_before_list (
 Stub tests::test_unmanaged_tx_raises_tx_closed_exec (tests.stub.tx_lifetime.test_tx_lifetime.TestTxLifetime.test_unmanaged_tx_raises_tx_closed_exec)
 Stub tests::test_unsupported_type (tests.stub.datatypes.test_unsupported_type.TestUnsupportedTypes.test_unsupported_type)
 Stub tests::test_unsupported_type_in_list (tests.stub.datatypes.test_unsupported_type.TestUnsupportedTypes.test_unsupported_type_in_list)
+Stub tests::test_warm_cache_during_cluster_upgrade (tests.stub.homedb.test_homedb.TestHomeDbMixedCluster.test_warm_cache_during_cluster_upgrade)
 Stub tests::test_warm_router_failure (tests.stub.authorization.verify_authentication.test_verify_authentication.TestVerifyAuthenticationV5x1.test_warm_router_failure)

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -100,3 +100,31 @@ the `it` implicit block parameter in pipeline-style code (e.g.
 to Ruby 3.4 in lockstep. Two version bumps in three days is fine
 while we're pre-1.0; once the API stabilises we'll be more
 conservative about minimum-Ruby moves.
+
+## 2026-06-05 — Connection-pool metrics deferred (shaded-jar ABI clash)
+
+`get_connection_pool_metrics` (testkit) / `Driver#metrics` stays
+unimplemented. The gem bundles the **shaded** `neo4j-java-driver-all`
+uber jar (relocates bolt-connection → `…internal.shaded.bolt.connection`).
+The `neo4j-java-driver-observation-metrics` module is built against the
+**unshaded** driver, so its `boltExchange(…, org.neo4j.bolt.connection
+.BoltProtocolVersion, …)` doesn't satisfy the all-jar's
+`DriverObservationProvider.boltExchange(…, internal.shaded…
+BoltProtocolVersion, …)` → `AbstractMethodError` on the first query.
+The two jars cannot interoperate. Java sidesteps this: its testkit-backend
+depends on the unshaded modular `neo4j-java-driver` + observation-metrics,
+while the shaded `-all` (Maven module `bundle`) is a prod convenience
+fat-jar that is *also* metrics-incompatible. We ship one jar for both
+prod and testkit, and the ext layer is hardwired to shaded class names.
+
+Skipped because it unlocks only 5 near-duplicate stub tests
+(`test_should_drop_connections_failing_liveness_check` ×
+v3/v4x2/v4x3/v4x4/v5x0, gated on Feature:API:Liveness.Check) at the cost
+of migrating the whole JRuby ext off the shaded jar.
+
+When the MRI metrics path is built (MRI's `Driver#pool_metrics` currently
+raises NotImplementedError), keep the testkit handler shape compatible
+with a *hypothetical unshaded JRuby build* too: consume a duck-typed
+metrics object (`connection_pool_metrics` → items responding to
+`id`/`in_use`/`idle`), and match the requested address by parsing `id`
+as `"host:port-…"`, mirroring Java's `GetConnectionPoolMetrics`.

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -76,7 +76,7 @@ module TestkitBackend
         'Feature:API:Driver.VerifyAuthentication'           => 'jar',
         'Feature:API:Driver.VerifyConnectivity'             => 'jr',
         'Feature:API:Driver.SupportsSessionAuth'            => 'jar',
-        'Feature:API:Driver:MaxConnectionLifetime'          => 'ar',
+        'Feature:API:Driver:MaxConnectionLifetime'          => 'jar',
         'Feature:API:Liveness.Check'                        => 'jar',
         'Feature:API:Result.List'                           => 'jar',
         'Feature:API:Result.Peek'                           => 'jar',

--- a/testkit-backend/requests/new_driver.rb
+++ b/testkit-backend/requests/new_driver.rb
@@ -26,6 +26,7 @@ module TestkitBackend
           # driver_metrics: true,
           max_transaction_retry_time: timeout_duration(max_tx_retry_time_ms),
           connection_liveness_check_timeout: timeout_duration(liveness_check_timeout_ms),
+          max_connection_lifetime: timeout_duration(max_connection_lifetime_ms),
           max_connection_pool_size: max_connection_pool_size,
           connection_acquisition_timeout: timeout_duration(connection_acquisition_timeout_ms),
           encryption: encrypted,


### PR DESCRIPTION
## Summary
- Thread `maxConnectionLifetimeMs` through `NewDriver` → `max_connection_lifetime` config, and flip `Feature:API:Driver:MaxConnectionLifetime` from `'ar'` to `'jar'`.
- The feature only means "driver accepts `max_connection_lifetime_ms`". JRuby's `ConfigConverter` already maps `max_connection_lifetime` → `withMaxConnectionLifetime(ms, MILLISECONDS)` (the `/time(out)?$/` key regex matches "lifetime"); the only gap was that `NewDriver` never passed the field through.
- The gating test (`homedb test_warm_cache_during_cluster_upgrade`, requires Bolt 5.7 + MaxConnectionLifetime) exercises it via FakeTime + max-lifetime pool eviction — not via the metrics API. FakeTime (Backend:MockTime, shipped in #344) already swaps the pool's clock through `DriverFactory#createClock`, so ticking past the lifetime evicts the connection deterministically.

## Scope note
Plan item #4 also mentioned `driver.metrics` / `get_connection_pool_metrics`. That is a **separate** concern (used only by `test_should_drop_connections_failing_liveness_check` ×5 Bolt versions, gated on `Feature:API:Liveness.Check`) and is **blocked**: the bundled shaded `neo4j-java-driver-all` uber jar is ABI-incompatible with the unshaded-built `observation-metrics` module (`AbstractMethodError` on `boltExchange` — shaded vs unshaded `BoltProtocolVersion`). Java's own testkit avoids this by depending on the unshaded modular driver; our gem ships one shaded jar. Unblocking requires migrating off the shaded jar — a separate, larger effort. Deferred by decision.

## Test plan
- [x] Config conversion verified in isolation: `max_connection_lifetime: 2s` → `withMaxConnectionLifetime(2000, MILLISECONDS)`; omitted → Java default (3600000ms) unchanged.
- [x] `bundle exec rspec spec/shared` against live Neo4j — 404 examples, 0 failures, 1 pending.
- [ ] Watch testkit CI; fold the newly-passing homedb test into the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Features**
  * Java and JRuby drivers now advertise support for maximum connection lifetime.
  * Driver configuration now exposes a maximum connection lifetime setting.

* **Documentation**
  * Added decision note: connection-pool metrics support is deferred and a future approach is planned.

* **Tests**
  * Added a stub entry for a warm-cache cluster-upgrade test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->