### PR TITLE
chore: bump neo4j-java-driver 6.0.3 → 6.1.0 + testkit 6.x latest

### DIFF
--- a/neo4j-ruby-driver-java.gemspec
+++ b/neo4j-ruby-driver-java.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'concurrent-ruby-edge', '>= 0.6.0'
   spec.add_dependency 'jar-dependencies', '>= 0.5.5'
   spec.add_development_dependency 'ruby-maven', '>= 0'
-  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-all, 6.0.3'
-  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-observation-metrics, 6.0.3'
+  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-all, 6.1.0'
+  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-observation-metrics, 6.1.0'
   # spec.requirements << 'jar org.neo4j.bolt, neo4j-bolt-connection-pooled, 10.1.0'
 end

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,6 @@
 {
   "testkit": {
     "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "a233c3f32c9e7db33d856345c4c98f487d15aabb"
+    "ref": "a342fd02966075f4b21685074ad929d6a126d25f"
   }
 }


### PR DESCRIPTION
## Summary
- `neo4j-java-driver-all` + `neo4j-java-driver-observation-metrics`: **6.0.3 → 6.1.0** (latest GA on Maven Central).
- testkit pinned ref: `a233c3f` → `a342fd0` (HEAD of `neo4j-drivers/testkit` `6.x` as of 2026-06-05).

Smoke PR to surface what the new combination breaks (if anything) across rspec / testkit / testkit-stub / testkit-tls.

## Test plan
- [ ] rspec across all 3 ruby/jruby matrix rows × 3 neo4j server versions
- [ ] testkit (mri/jruby/mri-on-jruby)
- [ ] testkit-stub (mri/jruby/mri-on-jruby)
- [ ] testkit-tls (mri/jruby/mri-on-jruby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Neo4j Java driver dependencies to version 6.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->