### PR TITLE
testkit(get-features): sync feature list with testkit + neo4j-java-driver

### DIFF
--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -25,7 +25,7 @@ module TestkitBackend
         # we negotiate via HandshakeManifestV1; older servers ignore
         # the sentinel and pick from the legacy slots.
         'Feature:Bolt:3.0'                                  => 'ja',
-        'Feature:Bolt:4.1'                                  => 'ja',
+        'Feature:Bolt:4.1'                                  => 'j',
         'Feature:Bolt:4.2'                                  => 'jar',
         'Feature:Bolt:4.3'                                  => 'jar',
         'Feature:Bolt:4.4'                                  => 'jar',
@@ -70,6 +70,7 @@ module TestkitBackend
         'Feature:API:BookmarkManager'                       => 'jar',
         'Feature:API:ConnectionAcquisitionTimeout'          => 'jar',
         'Feature:API:Driver.ExecuteQuery'                   => 'ja',
+        'Feature:API:Driver.ExecuteQuery:WithAuth'          => 'a',
         'Feature:API:Driver:GetServerInfo'                  => '',
         'Feature:API:Driver.IsEncrypted'                    => 'jar',
         'Feature:API:Driver:NotificationsConfig'            => 'ja',
@@ -82,13 +83,14 @@ module TestkitBackend
         'Feature:API:Result.Peek'                           => 'jar',
         'Feature:API:Result.Single'                         => 'jar',
         'Feature:API:Result.SingleOptional'                 => '',
-        'Feature:API:RetryableExceptions'                   => '',
+        'Feature:API:RetryableExceptions'                   => 'a',
         'Feature:API:Session:AuthConfig'                    => 'jar',
         'Feature:API:Session:NotificationsConfig'           => 'a',
         'Feature:API:SSLClientCertificate'                  => 'ja', # JRuby: ClientCertificateManager via DriverFactory; MRI mTLS not wired
         'Feature:API:SSLConfig'                             => 'jar',
         'Feature:API:SSLSchemes'                            => 'jar',
         'Feature:API:Summary:GqlStatusObjects'              => 'ja',
+        'Feature:API:Summary:Profile:OptionalStats'         => '',
         'Feature:API:Type.Spatial'                          => '',
         'Feature:API:Type.Temporal'                         => 'ja',  # jruby: wraps Java's temporal types directly; MRI ('r') still has subtest gating gaps
         'Feature:API:Type.UnsupportedType'                  => 'ja',
@@ -96,7 +98,7 @@ module TestkitBackend
 
         # --- Other features --------------------------------------------------
         'Feature:Impersonation'                             => 'jar',
-        'Feature:IdempotentRetries'                         => '',
+        'Feature:IdempotentRetries'                         => 'a',
 
         # --- Optimizations ---------------------------------------------------
         'Optimization:AuthPipelining'                       => 'ja',
@@ -104,9 +106,11 @@ module TestkitBackend
         'Optimization:EagerTransactionBegin'                => 'ja',
         'Optimization:ExecuteQueryPipelining'               => 'ja',
         'Optimization:HomeDatabaseCache'                    => 'ja',
+        'Optimization:HomeDbCacheBasicPrincipalIsImpersonatedUser'  => '',
         'Optimization:ImplicitDefaultArguments'             => 'ja',
         'Optimization:MinimalBookmarksSet'                  => '',
         'Optimization:MinimalResets'                        => '',  # disabled in Java too
+        'Optimization:MinimalVerifyAuthentication'          => '',
         'Optimization:PullPipelining'                       => 'ja',
         'Optimization:ResultListFetchAll'                   => 'ja',
 
@@ -126,7 +130,7 @@ module TestkitBackend
         'ConfHint:connection.recv_timeout_seconds'          => 'ja',
         'Detail:ClosedDriverIsEncrypted'                    => '',
         'Detail:DefaultSecurityConfigValueEquality'         => 'ja',
-        'Detail:NumberIsNumber'                             => 'jar'
+        'Detail:NumberIsNumber'                             => 'jr'
       }.freeze
 
       def process

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -39,6 +39,7 @@ module TestkitBackend
         'Feature:Bolt:5.7'                                  => 'jar',
         'Feature:Bolt:5.8'                                  => 'jar',
         'Feature:Bolt:6.0'                                  => 'jar',
+        'Feature:Bolt:6.1'                                  => '',
         'Feature:Bolt:HandshakeManifestV1'                  => 'jar',
         'Feature:Bolt:Patch:UTC'                            => 'ja',
 
@@ -94,6 +95,7 @@ module TestkitBackend
         'Feature:API:Type.Spatial'                          => '',
         'Feature:API:Type.Temporal'                         => 'ja',  # jruby: wraps Java's temporal types directly; MRI ('r') still has subtest gating gaps
         'Feature:API:Type.UnsupportedType'                  => 'ja',
+        'Feature:API:Type.UUID'                             => '',
         'Feature:API:Type.Vector'                           => '',
 
         # --- Other features --------------------------------------------------


### PR DESCRIPTION
## Summary

Cross-check the `FEATURES` table in `testkit-backend/requests/get_features.rb` against:

- testkit's [`nutkit/protocol/feature.py`](https://github.com/neo4j-drivers/testkit/blob/master/nutkit/protocol/feature.py) (full universe of feature strings)
- neo4j-java-driver's [`GetFeatures.java`](https://github.com/neo4j/neo4j-java-driver/blob/main/testkit-backend/src/main/java/neo4j/org/testkit/backend/messages/requests/GetFeatures.java) `COMMON_FEATURES` + `SYNC_FEATURES` (what the upstream sync Java driver claims — relevant for `'a'`)

### Add 4 entries (in testkit but not in our map)

| Key | Value | Why |
|---|---|---|
| `Feature:API:Driver.ExecuteQuery:WithAuth` | `'a'` | Java claims it in `SYNC_FEATURES` |
| `Feature:API:Summary:Profile:OptionalStats` | `''` | Java does not claim |
| `Optimization:HomeDbCacheBasicPrincipalIsImpersonatedUser` | `''` | Java does not claim |
| `Optimization:MinimalVerifyAuthentication` | `''` | Java does not claim |

### Reconcile the `'a'` tag with Java's GetFeatures.java

Add `'a'` where Java supports the feature but our value was missing it:

| Key | Before | After |
|---|---|---|
| `Feature:API:RetryableExceptions` | `''` | `'a'` |
| `Feature:IdempotentRetries` | `''` | `'a'` |

Strip `'a'` where Java does NOT claim the feature in `COMMON_FEATURES` ∪ `SYNC_FEATURES`:

| Key | Before | After | Notes |
|---|---|---|---|
| `Feature:Bolt:4.1` | `'ja'` | `'j'` | Java's `COMMON_FEATURES` lists `Bolt:4.2`+ but not 4.1 |
| `Detail:NumberIsNumber` | `'jar'` | `'jr'` | This detail describes drivers that cannot differentiate int from float (JavaScript). Java differentiates `int`/`long`/`double` — should not have claimed `'a'` |

### Behaviour

`'a'` is informational only — `process()` matches on `'j'`/`'r'` to pick what each Ruby flavour advertises. **No advertised feature set changes for either MRI or JRuby**; this PR only corrects what the legend column documents about the upstream Java driver.

## Test plan

- [ ] Manual: \`ruby -c testkit-backend/requests/get_features.rb\` → Syntax OK (verified locally)
- [ ] Diff the post-change \`j\`/\`r\` slices against the pre-change ones — both should be unchanged
- [ ] CI: full testkit run on both flavours — no new pass/fail movement is the expected result

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated feature support mappings to reflect current driver capabilities.
  * Java driver now advertises specific Java-only features and a new execute-query-with-auth capability.
  * Retryable-exceptions and idempotent-retries are now advertised.
  * Added optional summary/profile stats and initial advertising for Bolt 6.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->