### PR TITLE
fix(mri): classify raw transport errors from Connection#connect

### DIFF
--- a/.github/testkit-tls-baseline-mri.txt
+++ b/.github/testkit-tls-baseline-mri.txt
@@ -12,6 +12,8 @@ TLS tests::test_driver_is_encrypted (tests.tls.test_secure_scheme.TestTrustSyste
 TLS tests::test_driver_is_encrypted (tests.tls.test_self_signed_scheme.TestSelfSignedScheme.test_driver_is_encrypted)
 TLS tests::test_driver_is_encrypted (tests.tls.test_self_signed_scheme.TestTrustAllCertsConfig.test_driver_is_encrypted)
 TLS tests::test_driver_is_not_encrypted (tests.tls.test_unsecure_scheme.TestUnsecureScheme.test_driver_is_not_encrypted)
+TLS tests::test_secure_server (tests.tls.test_unsecure_scheme.TestUnsecureScheme.test_secure_server)
+TLS tests::test_secure_server_explicitly_disabled_encryption (tests.tls.test_unsecure_scheme.TestUnsecureScheme.test_secure_server_explicitly_disabled_encryption)
 TLS tests::test_trusted_ca_correct_hostname (tests.tls.test_secure_scheme.TestSecureScheme.test_trusted_ca_correct_hostname)
 TLS tests::test_trusted_ca_correct_hostname (tests.tls.test_secure_scheme.TestTrustCustomCertsConfig.test_trusted_ca_correct_hostname)
 TLS tests::test_trusted_ca_correct_hostname (tests.tls.test_secure_scheme.TestTrustSystemCertsConfig.test_trusted_ca_correct_hostname)

--- a/lib/mri/neo4j/driver/bolt/connection.rb
+++ b/lib/mri/neo4j/driver/bolt/connection.rb
@@ -68,8 +68,13 @@ module Neo4j
           # mri (test_secure_server_explicitly_disabled_encryption).
           raise last_error if last_error.is_a?(Exceptions::Neo4jException)
 
-          raise Exceptions::ServiceUnavailableException,
-                "Unable to connect to #{@address || @uri}: #{last_error.class}: #{last_error.message}"
+          # Keep the original transport error (and its backtrace) as a
+          # suppressed exception so the underlying failure location is
+          # not lost behind the wrapper.
+          raise Exceptions::ServiceUnavailableException.new(
+            "Unable to connect to #{@address || @uri}: #{last_error.class}: #{last_error.message}",
+            suppressed: [last_error]
+          )
         end
 
         # Lightweight RESET-based liveness probe. Used by Bolt::Pool

--- a/lib/mri/neo4j/driver/bolt/connection.rb
+++ b/lib/mri/neo4j/driver/bolt/connection.rb
@@ -54,7 +54,22 @@ module Neo4j
             end
           end
 
-          raise last_error || Exceptions::ServiceUnavailableException.new('No addresses to connect to')
+          raise Exceptions::ServiceUnavailableException, 'No addresses to connect to' if last_error.nil?
+
+          # A Neo4jException (e.g. the handshake's ServiceUnavailable) is
+          # already classified — propagate as-is. A raw transport error
+          # (Errno::ECONNRESET when a plaintext client hits a TLS-only
+          # server, EOFError on a mid-handshake close, …) must be wrapped
+          # so callers see a DriverError rather than a bare SystemCallError.
+          # Without this, native MRI's C-OpenSSL leaks Errno::ECONNRESET and
+          # the testkit-backend reports a generic BackendError instead of a
+          # DriverError — the one TLS test where mri-on-jruby (whose Java
+          # socket layer surfaces a classified error) diverged from native
+          # mri (test_secure_server_explicitly_disabled_encryption).
+          raise last_error if last_error.is_a?(Exceptions::Neo4jException)
+
+          raise Exceptions::ServiceUnavailableException,
+                "Unable to connect to #{@address || @uri}: #{last_error.class}: #{last_error.message}"
         end
 
         # Lightweight RESET-based liveness probe. Used by Bolt::Pool


### PR DESCRIPTION
## Summary
`Bolt::Connection#connect` caught `IOError` / `SystemCallError` per address but **re-raised the last one raw**. A raw `Errno::ECONNRESET` / `Errno::EPIPE` (e.g. a plaintext client hitting a TLS-only server, which resets/closes the handshake) then escaped unwrapped, so the testkit-backend reported a generic `BackendError` instead of a classified `DriverError`.

Now: an already-classified `Neo4jException` (the handshake's `ServiceUnavailable`) propagates as-is; a raw transport error is wrapped in `ServiceUnavailableException`.

## How it surfaced
`testkit-tls` `TestUnsecureScheme` errored where it should report a clean connection failure:
- `test_secure_server_explicitly_disabled_encryption` — ERRORed on **native mri** (`ECONNRESET`), passed on **mri-on-jruby** (Java socket layer already classifies). This was the one TLS test where the two MRI flavors diverged (mri 15 pass / 3 err vs mri-on-jruby 16 pass / 2 err — same 43-test total).
- `test_secure_server` — ERRORed on **both** flavors (`Broken pipe` / `EPIPE`), same unwrapped-transport-error root cause.

Wrapping at `connect` fixes the shared cause, aligning both MRI flavors and likely turning both `TestUnsecureScheme` errors into passes.

## Verified
Unit: a stubbed `open_socket` raising `Errno::ECONNRESET` now yields `ServiceUnavailableException` (a `DriverError`); a handshake `ServiceUnavailableException` passes through unchanged.

## Follow-up
If CI shows new TLS passes, fold them into `.github/testkit-tls-baseline-mri.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection error reporting: clearer, more informative failure messages and consistent propagation of underlying transport errors to help diagnose connection and connectivity issues.
* **Tests**
  * Updated TLS test baseline to include two additional expected-passing regression tests covering unsecure-scheme secure-server scenarios, improving test coverage for TLS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->