### PR TITLE
ci: fix testkit summary counts for subTest suites (TLS)

### DIFF
--- a/.github/actions/testkit-postprocess/action.yml
+++ b/.github/actions/testkit-postprocess/action.yml
@@ -179,7 +179,7 @@ runs:
         # Pass = Ran - failures - errors - skipped, matching unittest's
         # own arithmetic.
         read -r PASS FAIL ERROR SKIP < <(awk '
-          /^Ran [0-9]+ tests/ { ran += $2 }
+          /^Ran [0-9]+ tests?/ { ran += $2 }
           # No \b — POSIX awk (the CI runner default) does not support it.
           /^(OK|FAILED)/ {
             if (match($0, /failures=[0-9]+/)) fail += substr($0, RSTART+9, RLENGTH-9)

--- a/.github/actions/testkit-postprocess/action.yml
+++ b/.github/actions/testkit-postprocess/action.yml
@@ -166,15 +166,28 @@ runs:
       shell: bash
       run: |
         LOG="${{ steps.log.outputs.path }}"
-        # Raw counts — every parametrised occurrence is its own
-        # pass/fail/error result. The dedup'd unique-test-id count
-        # used by the gate is reported separately below.
-        # Count both shapes (inline " ... ok" and bare "ok" after a
-        # warning-split header) so warnings don't make the totals lie.
-        PASS=$(awk '/ \.\.\. ok$/ { c++; next } /^ok$/ { c++ } END { print c+0 }' "$LOG")
-        FAIL=$(awk '/ \.\.\. FAIL$/ { c++; next } /^FAIL$/ { c++ } END { print c+0 }' "$LOG")
-        ERROR=$(awk '/ \.\.\. ERROR$/ { c++; next } /^ERROR$/ { c++ } END { print c+0 }' "$LOG")
-        SKIP=$(grep -cE 'skipped' "$LOG" || true)
+        # Parse unittest's own end-of-run summary lines rather than the
+        # inline " ... ok/FAIL/ERROR" tokens. With subTests (the TLS
+        # suite runs each test per scheme= subtest), a failing subtest
+        # does NOT print " ... FAIL" inline — the method still prints
+        # "ok" and the failures surface as end-of-run "FAIL:" / "ERROR:"
+        # blocks, so the old inline-token count reported Fail 0 / Error 0
+        # even with 20 failures. unittest prints, once per run (and the
+        # integration suite runs once per Neo4j config, so we SUM):
+        #     Ran N tests in T
+        #     OK | OK (skipped=S) | FAILED (failures=F, errors=E, skipped=S)
+        # Pass = Ran - failures - errors - skipped, matching unittest's
+        # own arithmetic.
+        read -r PASS FAIL ERROR SKIP < <(awk '
+          /^Ran [0-9]+ tests/ { ran += $2 }
+          # No \b — POSIX awk (the CI runner default) does not support it.
+          /^(OK|FAILED)/ {
+            if (match($0, /failures=[0-9]+/)) fail += substr($0, RSTART+9, RLENGTH-9)
+            if (match($0, /errors=[0-9]+/))   err  += substr($0, RSTART+7, RLENGTH-7)
+            if (match($0, /skipped=[0-9]+/))  skip += substr($0, RSTART+8, RLENGTH-8)
+          }
+          END { printf "%d %d %d %d\n", ran-fail-err-skip, fail, err, skip }
+        ' "$LOG")
         {
           echo "## Testkit (${{ inputs.target_label }}) results"
           echo ""


### PR DESCRIPTION
## Summary
The "## Testkit (…) results" summary table reported **Fail 0 / Error 0** for the TLS suite even when 20 tests failed (e.g. [this run](https://github.com/neo4jrb/neo4j-ruby-driver/actions/runs/27077605565?pr=352) showed Pass 29 / Fail 0 / Error 0 / Skip 6).

**Cause:** the TLS suite runs each test as per-scheme `subTest`s. A failing subtest does **not** print `... FAIL` inline — the method still prints `ok`, and the failures surface only as end-of-run `FAIL:` / `ERROR:` summary blocks. The old awk counted inline `... ok/FAIL/ERROR` tokens, so it saw 29 ok / 0 fail / 0 error.

**Fix:** parse unittest's own summary lines (summed across the integration suite's per-config runs):
```
Ran N tests
OK | OK (skipped=S) | FAILED (failures=F, errors=E, skipped=S)
```
`Pass = Ran − failures − errors − skipped`.

## Verified
- TLS (mri): now **Pass 15 / Fail 20 / Error 3 / Skip 5** — matches `FAILED (failures=20, errors=3, skipped=5)`.
- Integration (8 configs): sums to **Pass 695**, matching the gate's unique-pass count.
- No `\b` in the awk (POSIX awk on the CI runner doesn't support it).

Informational only — the regression **gate** uses a separate, unaffected extraction, so merge decisions were always sound; this just makes the human-readable table honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI test-result accuracy by changing how test run summaries are parsed so Pass/Fail/Error/Skip totals are computed from end-of-run counts, fixing mismatches where some failing subtests weren’t previously tallied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->