### PR TITLE
fix(testkit): single-reader command loop — fixes routing auth-callback hang

### DIFF
--- a/testkit-backend/command_processor.rb
+++ b/testkit-backend/command_processor.rb
@@ -4,26 +4,94 @@ module TestkitBackend
       REQUEST_BEGIN = "#request begin"
       REQUEST_END = "#request end"
 
+      # Backend->frontend callback replies. The driver invokes the matching
+      # callbacks (auth-token manager, resolver, bookmark manager, …) from its
+      # own threads — for a routing driver that's Netty I/O threads, and more
+      # than one can be in flight at once. The reader routes these to the
+      # waiting callback instead of treating them as new top-level requests.
+      COMPLETION_NAMES = %w[
+        AuthTokenManagerGetAuthCompleted
+        AuthTokenManagerHandleSecurityExceptionCompleted
+        BasicAuthTokenProviderCompleted
+        BearerAuthTokenProviderCompleted
+        BookmarksSupplierCompleted
+        BookmarksConsumerCompleted
+        ClientCertificateProviderCompleted
+        DomainNameResolutionCompleted
+        ResolverResolutionCompleted
+      ].to_set.freeze
+
       def initialize(socket)
         @socket = socket
         @buffer = String.new
         @closed = false
         @debug = ENV["TESTKIT_DEBUG"] == "1"
+        # One reader thread owns the socket; everything else communicates
+        # through these. @io_mutex guards every write and the FIFO waiter
+        # list — never held across a blocking wait, so it can't deadlock.
+        @io_mutex = Mutex.new
+        @waiters = []
+        @requests = Queue.new
       end
 
-      def process(blocking: false)
-        while (var = read_chunk(blocking))
-          log_chunk(blocking ? "blocking:" : "nonblocking:", var)
-          @buffer << var
-          if (request_begin = find_request_begin) && (request_end = find_request_end(request_begin))
-            to_process = @buffer[request_begin...request_end[:start]]
-            @buffer = @buffer[(request_end[:line_end] + 1)..-1] || ""
-            return process_request(to_process)
+      # Sole socket reader. Frames each message and routes it: a callback
+      # reply goes to the oldest waiting callback (FIFO is correct because
+      # writes are serialised, so request order == reply order); anything
+      # else is a request for the executor to run.
+      def start_reader
+        @reader = Thread.new do
+          while (raw = read_message)
+            if COMPLETION_NAMES.include?(JSON.parse(raw, symbolize_names: true)[:name])
+              (@io_mutex.synchronize { @waiters.shift })&.push(raw)
+            else
+              @requests.push(raw)
+            end
           end
+        ensure
+          # Unblock any callback still waiting on a reply — the connection is
+          # gone, so its reply will never arrive (a closed Thread::Queue#pop
+          # returns nil). Otherwise that driver thread hangs forever.
+          @io_mutex.synchronize do
+            @waiters.each(&:close)
+            @waiters.clear
+          end
+          @requests.close
         end
-      rescue Errno::EBADF, Errno::EPIPE, IOError => e
-        warn "socket read failed: #{e.class}: #{e.message}"
-        nil
+      end
+
+      # Executor loop body: run the next queued request (parse, dispatch to
+      # its handler, write the response). Returns falsey when the reader has
+      # closed the connection.
+      def process_next
+        raw = @requests.pop
+        return false if raw.nil?
+
+        process_request(raw)
+        true
+      end
+
+      # Used by the managed-transaction handler to drain nested requests
+      # (TransactionRun, RetryablePositive/Negative …) that the frontend
+      # sends while the retry function runs. Returns the processed message.
+      def next_request
+        process_request(@requests.pop)
+      end
+
+      # Send a backend->frontend request and block for its reply. Register the
+      # waiter and write the request atomically so the FIFO order of waiters
+      # matches the order the frontend sees the requests (and thus replies).
+      def callback(request_message)
+        queue = Thread::Queue.new
+        @io_mutex.synchronize do
+          raise IOError, "connection closed" if @closed
+
+          @waiters.push(queue)
+          write_all(response(request_message))
+        end
+        raw = queue.pop
+        raise IOError, "connection closed while awaiting callback reply" unless raw
+
+        process_request(raw)
       end
 
       def process_request(request)
@@ -38,7 +106,7 @@ module TestkitBackend
         payload = response(response_message)
         return unless payload
 
-        write_all(payload)
+        @io_mutex.synchronize { write_all(payload) }
       end
 
       def to_testkit(name, object)
@@ -47,6 +115,27 @@ module TestkitBackend
 
       def response(message)
         "#response begin\n#{JSON.dump(message)}\n#response end\n".tap { |var| log_chunk("written:", var) } if message
+      end
+
+      # Read and return one complete framed message (blocking). Reader-thread
+      # only, so @buffer needs no locking.
+      def read_message
+        loop do
+          if (request_begin = find_request_begin) && (request_end = find_request_end(request_begin))
+            message = @buffer[request_begin...request_end[:start]]
+            @buffer = @buffer[(request_end[:line_end] + 1)..-1] || ""
+            return message
+          end
+
+          chunk = read_chunk(true)
+          return nil unless chunk
+
+          log_chunk("blocking:", chunk)
+          @buffer << chunk
+        end
+      rescue Errno::EBADF, Errno::EPIPE, IOError => e
+        warn "socket read failed: #{e.class}: #{e.message}"
+        nil
       end
 
       def read_chunk(blocking)

--- a/testkit-backend/requests/new_auth_token_manager.rb
+++ b/testkit-backend/requests/new_auth_token_manager.rb
@@ -20,17 +20,16 @@ module TestkitBackend
       private
 
       def get_token(manager_id)
-        @command_processor.process_response(
+        reply = @command_processor.callback(
           named_entity('AuthTokenManagerGetAuthRequest', id: manager_id, auth_token_manager_id: manager_id))
-        Request.object_from(@command_processor.process(blocking: true).auth)
+        Request.object_from(reply.auth)
       end
 
       def handle_security_exception(manager_id, token, exception)
-        @command_processor.process_response(
+        @command_processor.callback(
           named_entity('AuthTokenManagerHandleSecurityExceptionRequest',
                        id: manager_id, auth_token_manager_id: manager_id,
-                       auth: serialize_auth_token(token), error_code: exception.code))
-        @command_processor.process(blocking: true).handled
+                       auth: serialize_auth_token(token), error_code: exception.code)).handled
       end
 
       # Reverse of AuthorizationToken#to_object — AuthToken back to

--- a/testkit-backend/requests/new_basic_auth_token_manager.rb
+++ b/testkit-backend/requests/new_basic_auth_token_manager.rb
@@ -22,9 +22,9 @@ module TestkitBackend
       private
 
       def supply(manager_id)
-        @command_processor.process_response(
+        reply = @command_processor.callback(
           named_entity('BasicAuthTokenProviderRequest', id: manager_id, basic_auth_token_manager_id: manager_id))
-        Request.object_from(@command_processor.process(blocking: true).auth)
+        Request.object_from(reply.auth)
       end
     end
   end

--- a/testkit-backend/requests/new_bearer_auth_token_manager.rb
+++ b/testkit-backend/requests/new_bearer_auth_token_manager.rb
@@ -27,9 +27,8 @@ module TestkitBackend
       private
 
       def supply(manager_id)
-        @command_processor.process_response(
-          named_entity('BearerAuthTokenProviderRequest', id: manager_id, bearer_auth_token_manager_id: manager_id))
-        body = @command_processor.process(blocking: true).auth[:data]
+        body = @command_processor.callback(
+          named_entity('BearerAuthTokenProviderRequest', id: manager_id, bearer_auth_token_manager_id: manager_id)).auth[:data]
         token = Request.object_from(body[:auth])
         expires_in_ms = body[:expiresInMs]
         expires_at_ms = expires_in_ms && Internal::TestkitClock::INSTANCE.now_millis + expires_in_ms

--- a/testkit-backend/requests/new_bookmark_manager.rb
+++ b/testkit-backend/requests/new_bookmark_manager.rb
@@ -26,17 +26,15 @@ module TestkitBackend
       private
 
       def supply(bookmark_manager_id)
-        @command_processor.process_response(
-          named_entity('BookmarksSupplierRequest', id: bookmark_manager_id, bookmark_manager_id: bookmark_manager_id))
-        bookmarks = @command_processor.process(blocking: true).bookmarks || []
+        bookmarks = @command_processor.callback(
+          named_entity('BookmarksSupplierRequest', id: bookmark_manager_id, bookmark_manager_id: bookmark_manager_id)).bookmarks || []
         bookmarks.map(&Neo4j::Driver::Bookmark.method(:from))
       end
 
       def consume(bookmark_manager_id, bookmarks)
-        @command_processor.process_response(
+        @command_processor.callback(
           named_entity('BookmarksConsumerRequest', id: bookmark_manager_id, bookmark_manager_id: bookmark_manager_id,
                        bookmarks: bookmarks.map(&:value)))
-        @command_processor.process(blocking: true)
         nil
       end
     end

--- a/testkit-backend/requests/new_client_certificate_provider.rb
+++ b/testkit-backend/requests/new_client_certificate_provider.rb
@@ -23,9 +23,8 @@ module TestkitBackend
       private
 
       def request_client_certificate(provider_id)
-        @command_processor.process_response(
+        completed = @command_processor.callback(
           named_entity('ClientCertificateProviderRequest', id: provider_id, client_certificate_provider_id: provider_id))
-        completed = @command_processor.process(blocking: true)
         return unless completed.has_update
 
         # The wire shape nests the cert fields under `data`.

--- a/testkit-backend/requests/new_driver.rb
+++ b/testkit-backend/requests/new_driver.rb
@@ -73,13 +73,11 @@ module TestkitBackend
       end
 
       def domain_name_resolver(name)
-        @command_processor.process_response(named_entity('DomainNameResolutionRequired', id: object_id, name: name))
-        @command_processor.process(blocking: true).addresses
+        @command_processor.callback(named_entity('DomainNameResolutionRequired', id: object_id, name: name)).addresses
       end
 
       def callback_resolver(address)
-        @command_processor.process_response(named_entity('ResolverResolutionRequired', id: object_id, address: address))
-        @command_processor.process(blocking: true).addresses.map do |addr|
+        @command_processor.callback(named_entity('ResolverResolutionRequired', id: object_id, address: address)).addresses.map do |addr|
           addr.rpartition(':').then { |host, _, port| Neo4j::Driver::Net::ServerAddress.of(host, port.to_i) }
         end
       end

--- a/testkit-backend/requests/session_transaction.rb
+++ b/testkit-backend/requests/session_transaction.rb
@@ -5,7 +5,7 @@ module TestkitBackend
         fetch(session_id).send(method, metadata: decode(tx_meta), timeout: timeout_duration) do |tx|
           tx_id = store(tx)
           @command_processor.process_response(named_entity('RetryableTry', id: tx_id))
-          until @command_processor.process(blocking: true).is_a?(Retryable) do
+          until @command_processor.next_request.is_a?(Retryable) do
           end
         ensure
           delete(tx_id)

--- a/testkit-backend/runner.rb
+++ b/testkit-backend/runner.rb
@@ -26,7 +26,13 @@ module TestkitBackend
       # overflows and testkit gets ConnectionRefused on retries.
       Thread.new(socket, host, port) do |sock, h, p|
         cp = CommandProcessor.new(sock)
-        while cp.process(blocking: true) do
+        # A dedicated reader thread owns the socket; this thread is the
+        # executor that runs requests. Driver callbacks (auth manager,
+        # resolver, …) fire on driver-owned threads and round-trip via
+        # CommandProcessor#callback, so nothing but the reader touches the
+        # socket for reads — concurrent routing callbacks can't race.
+        cp.start_reader
+        while cp.process_next do
         end
       rescue StandardError => e
         warn "*** #{h}:#{p} handler crashed: #{e.class}: #{e.message}"


### PR DESCRIPTION
## Summary
Fixes the largest cluster of JRuby stub testkit **errors** — the routing `test_auth_token_manager` tests that hung ~13s (frontend timeout) / 60s (driver connection-acquisition timeout).

### Root cause
A **routing** driver invokes the auth-manager / resolver / bookmark callbacks from its own threads (Netty I/O), **several concurrently** (e.g. `getToken` on one event-loop thread, `handleSecurityException` on another). Each round-trips to the frontend through the single, non-thread-safe `CommandProcessor`; concurrent blocking reads cross each other's replies, the callbacks never return, and the driver spins to its 60s acquisition timeout. A plain mutex can't fully close it — the **executor's own reads** still race the callbacks (confirmed flaky: 0–10 errors run-to-run).

### Fix — one thread owns the socket
- A dedicated **reader** thread frames every message and routes it: callback replies (`COMPLETION_NAMES`) → the oldest waiting callback; everything else → a request queue. FIFO matching is correct because all writes are serialised, so request order == reply order.
- The connection thread becomes the **executor**, draining the queue (`process_next`); the managed-tx handler drains nested requests via `next_request`.
- Callbacks use `CommandProcessor#callback`: register a waiter + write the request under one mutex (held only briefly, never across a blocking wait → no deadlock), then block on a per-call queue the reader fulfils. The managed-tx retry callback no longer needs special-casing.

No thread but the reader reads the socket, so concurrent routing callbacks can't race.

## Verified (JRuby)
- `TestAuthTokenManager5x0` `session_run` (was flaky 0–10 errors): **reliably 0** across repeated runs; managed-`tx_run`: **0**.
- Full `test_auth_token_manager`: errors **81 → 0** (remaining failures are the upstream testkit `no error mapping for ruby` gap — see below).
- Routing / tx_run stub suites: **no hangs** (residual local `StubServerUncleanExitError` is port exhaustion from tests now running fast — flaky run-to-run locally, absent in CI's container harness).

## Follow-up (separate)
The remaining auth *failures* are testkit-side: `assert_is_*` helpers hardcode per-driver `errorType` and omit `ruby` in `_assert_is_retryable_*` / `assert_is_random_error`. testkit's GQLSTATUS error API exists (ruby advertises `Feature:API:Summary:GqlStatusObjects`) but these helpers predate it. A small testkit PR (add `ruby`, or migrate to gqlStatus) clears those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved socket reading to a dedicated background reader and decoupled request execution into a non-blocking, request-driven loop.
  * Replaced blocking process flow with callback-driven interactions across auth, bookmark, driver resolution, certificate and transaction flows.
  * Ensured serialized socket writes and FIFO completion dispatching for safer concurrency and more consistent async behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->