### PR TITLE
docs: clarify main (not 4.4) is the dev branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Neo4j Ruby Driver
 
+## Branches
+
+`main` is the active development branch — base feature branches on it and
+target PRs at it. `4.4` is a diverged, older release line (it predates the
+JRuby/shared split and the auth-manager work); don't branch off it.
+
 ## Essential References
 
 ### Specifications


### PR DESCRIPTION
Adds a short **Branches** note to CLAUDE.md: `main` is the active development branch (base feature branches on it, target PRs at it); `4.4` is a diverged older release line that predates the JRuby/shared split and auth-manager work.

Context: the local `origin/HEAD` was pointing at `4.4`, so tooling reported `4.4` as the "main branch" and a feature branch got based off the wrong (diverged) line. `origin/HEAD` has been repointed to `main`; this note makes the intent explicit in the doc too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines regarding branch management and pull request targeting.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->