### PR TITLE
ci(testkit): temporarily pin testkit to the fork branch (ruby error-mappings)

### DIFF
--- a/.github/workflows/testkit-full.yml
+++ b/.github/workflows/testkit-full.yml
@@ -75,7 +75,7 @@ jobs:
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/klobuczek/testkit.git
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit-stub.yml
+++ b/.github/workflows/testkit-stub.yml
@@ -77,7 +77,7 @@ jobs:
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/klobuczek/testkit.git
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit-tls.yml
+++ b/.github/workflows/testkit-tls.yml
@@ -55,7 +55,7 @@ jobs:
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/klobuczek/testkit.git
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -58,7 +58,7 @@ jobs:
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/klobuczek/testkit.git
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,6 +1,7 @@
 {
   "testkit": {
-    "uri": "https://github.com/neo4j-drivers/testkit.git",
-    "ref": "a342fd02966075f4b21685074ad929d6a126d25f"
+    "_comment": "TEMPORARY: pinned to the klobuczek/testkit fork branch carrying the ruby error-mapping additions (PR neo4j-drivers/testkit#717). Revert uri to neo4j-drivers/testkit.git and ref to a SHA once #717 merges upstream.",
+    "uri": "https://github.com/klobuczek/testkit.git",
+    "ref": "ruby-auth-error-mappings"
   }
 }


### PR DESCRIPTION
Points the testkit clone (4 workflows + `testkit/testkit.json`) at `klobuczek/testkit@ruby-auth-error-mappings`, which carries the ruby error-type branches (neo4j-drivers/testkit#717).

Needed so CI exercises the aligned ruby `errorType` assertions — otherwise the per-driver chains hit `no error mapping for ruby`, and the driver's `SecurityRetryableException`/`TransactionTerminatedException` alignment (#361) surfaces as regressions.

**Temporary** — revert `uri` to `neo4j-drivers/testkit.git` and `ref` to a pinned SHA once #717 merges upstream. Once merged here, rebase #360/#361 on main to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows and test kit configuration to use a temporary alternative test kit source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->