### PR TITLE
jruby(errors): chain cause at non-raise exception-mapping sites

### DIFF
--- a/lib/jruby/neo4j/driver/auth_token_manager.rb
+++ b/lib/jruby/neo4j/driver/auth_token_manager.rb
@@ -22,7 +22,7 @@ module Neo4j
       def get_token = java.util.concurrent.CompletableFuture.completed_future(super)
 
       def handle_security_exception(token, exception)
-        super(token, mapped_exception(exception))
+        super(token, mapped_exception_with_cause(exception))
       end
     end
   end

--- a/lib/jruby/neo4j/driver/ext/async_converter.rb
+++ b/lib/jruby/neo4j/driver/ext/async_converter.rb
@@ -51,9 +51,13 @@ module Neo4j::Driver::Ext
       if error
         # This raise is outside any rescue, so set cause explicitly (the
         # backtrace is correctly captured here, unlike the value-handoff
-        # helper). Mirrors mapped_exception(error.cause || error).
+        # helper). Guard the unmapped passthrough — `cause: original` when
+        # mapped == original is a self-cause.
         original = error.cause || error
-        raise mapped_exception(original), cause: original
+        mapped = mapped_exception(original)
+        raise mapped if mapped.equal?(original)
+
+        raise mapped, cause: original
       end
       value
     end

--- a/lib/jruby/neo4j/driver/ext/async_converter.rb
+++ b/lib/jruby/neo4j/driver/ext/async_converter.rb
@@ -38,7 +38,7 @@ module Neo4j::Driver::Ext
 
     def to_future(completion_stage)
       Concurrent::Promises.resolvable_future.tap do |future|
-        completion_stage.then_apply(&future.method(:fulfill)).exceptionally { |e| future.reject(mapped_exception(e.cause)) }
+        completion_stage.then_apply(&future.method(:fulfill)).exceptionally { |e| future.reject(mapped_exception_with_cause(e.cause)) }
       end
     end
 
@@ -48,7 +48,13 @@ module Neo4j::Driver::Ext
         variable.resolve([value, error])
       end
       value, error = variable.wait
-      raise mapped_exception(error.cause || error) if error
+      if error
+        # This raise is outside any rescue, so set cause explicitly (the
+        # backtrace is correctly captured here, unlike the value-handoff
+        # helper). Mirrors mapped_exception(error.cause || error).
+        original = error.cause || error
+        raise mapped_exception(original), cause: original
+      end
       value
     end
   end

--- a/lib/jruby/neo4j/driver/ext/exception_mapper.rb
+++ b/lib/jruby/neo4j/driver/ext/exception_mapper.rb
@@ -28,6 +28,24 @@ module Neo4j
             mapped_runtime_exception_class(exception)&.new(exception.message) || exception
         end
 
+        # Like mapped_exception, but chains the original Java exception as
+        # `.cause`. At a `raise mapped_exception(e)` site inside a
+        # `rescue => e` block Ruby sets `.cause` to the Java exception
+        # automatically (which reverse_check round-trips on via
+        # `throwable(e.cause)`). At sites that hand the mapped exception
+        # off as a *value* (AuthTokenManager#handle_security_exception,
+        # AsyncConverter's reject/raise-outside-rescue) there is no such
+        # auto-set, so do it explicitly here. Ruby has no `cause=` setter;
+        # `raise … cause:` is the only way to attach one.
+        def mapped_exception_with_cause(exception)
+          mapped = mapped_exception(exception)
+          return mapped if mapped.equal?(exception) # unmapped passthrough
+
+          raise mapped, cause: exception
+        rescue StandardError => e
+          e
+        end
+
         private
 
         def suppressed(e)

--- a/lib/jruby/neo4j/driver/ext/exception_mapper.rb
+++ b/lib/jruby/neo4j/driver/ext/exception_mapper.rb
@@ -39,10 +39,15 @@ module Neo4j
         # `raise … cause:` is the only way to attach one.
         def mapped_exception_with_cause(exception)
           mapped = mapped_exception(exception)
-          return mapped if mapped.equal?(exception) # unmapped passthrough
+          return mapped if mapped.equal?(exception) # unmapped passthrough — no self-cause
 
           raise mapped, cause: exception
         rescue StandardError => e
+          # Only the mapped exception we just raised becomes a return
+          # value; anything else (e.g. a bug in mapped_exception) must
+          # propagate rather than be silently turned into a value.
+          raise unless e.equal?(mapped)
+
           e
         end
 


### PR DESCRIPTION
## Summary
JRuby's exception mapper carries the original Java exception through `.cause` — but only at `raise mapped_exception(e)` sites inside a `rescue => e`, where Ruby auto-sets it. (`reverse_check` round-trips on this via `throwable(e.cause)`.)

Three sites hand the mapped exception off **without** a raise-in-rescue, so `.cause` was `nil` there:
- `AuthTokenManager#handle_security_exception` — `super(token, mapped_exception(exception))`
- `AsyncConverter#to_future` — `future.reject(mapped_exception(e.cause))`
- `AsyncConverter#to_async` — `raise mapped_exception(error.cause || error)` (raise is *outside* any rescue)

## Fix
Ruby has no `cause=` setter, so attach via `raise … cause:`:
- `mapped_exception_with_cause` for the value-handoff sites (auth manager, future.reject).
- explicit `raise mapped_exception(orig), cause: orig` at `to_async` so the backtrace stays at the real raise site.

`.cause` stays the **original Java exception** (not a re-mapped Ruby one), consistent with the auto-set sites and with `reverse_check`'s Ruby→Java round-trip — so no behavioural change there, just filling the nil-cause gap.

## Notes
JRuby-only; the Java-exception path runs under the testkit-stub jruby job (auth-manager + async), which validates end-to-end. The MRI side already uses `cause` for its wraps (#359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling to preserve original exception causes across JRuby driver flows. Errors raised during async and auth-related operations now retain their underlying cause, making stack traces and debugging more accurate and actionable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->