### PR TITLE
ci(testkit): unpin from fork, track upstream 6.x

### DIFF
--- a/.github/workflows/testkit-full.yml
+++ b/.github/workflows/testkit-full.yml
@@ -72,10 +72,11 @@ jobs:
 
       - name: Clone pinned testkit
         run: |
+          URI=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['uri'])")
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin "$URI"
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit-full.yml
+++ b/.github/workflows/testkit-full.yml
@@ -75,7 +75,7 @@ jobs:
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/klobuczek/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit-stub.yml
+++ b/.github/workflows/testkit-stub.yml
@@ -77,7 +77,7 @@ jobs:
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/klobuczek/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit-stub.yml
+++ b/.github/workflows/testkit-stub.yml
@@ -74,10 +74,11 @@ jobs:
       # workflow no longer hardcodes it.
       - name: Clone pinned testkit
         run: |
+          URI=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['uri'])")
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin "$URI"
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit-tls.yml
+++ b/.github/workflows/testkit-tls.yml
@@ -52,10 +52,11 @@ jobs:
 
       - name: Clone pinned testkit
         run: |
+          URI=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['uri'])")
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin "$URI"
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit-tls.yml
+++ b/.github/workflows/testkit-tls.yml
@@ -55,7 +55,7 @@ jobs:
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/klobuczek/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -55,10 +55,11 @@ jobs:
 
       - name: Clone pinned testkit
         run: |
+          URI=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['uri'])")
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin "$URI"
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -58,7 +58,7 @@ jobs:
           REF=$(python3 -c "import json; print(json.load(open('testkit/testkit.json'))['testkit']['ref'])")
           mkdir -p "$RUNNER_TEMP/testkit"
           git -C "$RUNNER_TEMP/testkit" init
-          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/klobuczek/testkit.git
+          git -C "$RUNNER_TEMP/testkit" remote add origin https://github.com/neo4j-drivers/testkit.git
           git -C "$RUNNER_TEMP/testkit" fetch --depth 1 origin "$REF"
           git -C "$RUNNER_TEMP/testkit" checkout FETCH_HEAD
           echo "TESTKIT_PATH=$RUNNER_TEMP/testkit" >> "$GITHUB_ENV"

--- a/testkit/testkit.json
+++ b/testkit/testkit.json
@@ -1,7 +1,7 @@
 {
   "testkit": {
-    "_comment": "TEMPORARY: pinned to the klobuczek/testkit fork branch carrying the ruby error-mapping additions (PR neo4j-drivers/testkit#717). Revert uri to neo4j-drivers/testkit.git and ref to a SHA once #717 merges upstream.",
-    "uri": "https://github.com/klobuczek/testkit.git",
-    "ref": "ruby-auth-error-mappings"
+    "_comment": "Pinned testkit revision this driver is tested against (6.x). Bump to a newer 6.x SHA as needed.",
+    "uri": "https://github.com/neo4j-drivers/testkit.git",
+    "ref": "ec48679f816bf4bff382b368367b3225afd70082"
   }
 }


### PR DESCRIPTION
The ruby error-type branches (neo4j-drivers/testkit#717) and the session-auth backend fix are merged upstream, so the temporary fork pin is no longer needed.

- `testkit/testkit.json`: uri → `neo4j-drivers/testkit.git`, ref → `ec48679` (current 6.x HEAD, includes #717).
- The four testkit workflows: remote → upstream.
- Devcontainer needs no change (it reads uri+ref from `testkit.json`).

Verified locally against upstream 6.x: `test_auth_token_manager` 16/0/0, `test_tx_run` 16/3/0 (the 3 fails are pre-existing behavioral, not errorType).

Note: 6.x HEAD also carries #718 (a UUID java branch); its ruby branch is deferred (a separate UUID-types bucket), so that test remains a tolerated non-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to use the official Neo4j testkit repository as the primary source for testing, replacing the prior fork-based origin across test suites.
  * Pinned testkit dependency synchronized to the official repository and fixed to a specific upstream commit to improve consistency and reliability of test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->