### PR TITLE
feat(jruby): serialize GQL error cause chain + classification default

### DIFF
--- a/lib/jruby/neo4j/driver/ext/exception_mapper.rb
+++ b/lib/jruby/neo4j/driver/ext/exception_mapper.rb
@@ -11,6 +11,7 @@ module Neo4j
         java_import org.neo4j.driver.exceptions.DatabaseException
         java_import org.neo4j.driver.exceptions.DiscoveryException
         java_import org.neo4j.driver.exceptions.FatalDiscoveryException
+        java_import org.neo4j.driver.exceptions.Neo4jException
         java_import org.neo4j.driver.exceptions.ProtocolException
         java_import org.neo4j.driver.exceptions.ResultConsumedException
         java_import org.neo4j.driver.exceptions.SecurityException
@@ -77,8 +78,18 @@ module Neo4j
             status_description: unwrap_optional(e.try(:status_description)),
             classification: unwrap_optional(e.try(:classification))&.to_s,
             raw_classification: unwrap_optional(e.try(:raw_classification)),
-            diagnostic_record: unwrap_optional(e.try(:diagnostic_record))&.to_h
+            diagnostic_record: unwrap_optional(e.try(:diagnostic_record))&.to_h,
+            gql_cause: gql_cause(e)
           }
+        end
+
+        # The GQL cause chain (Neo4jException#gqlCause), mapped recursively so
+        # the Ruby exception carries the nested cause the testkit error shape
+        # asserts on. Each cause is itself a Neo4jException, so mapped_exception
+        # recurses (its own gqlCause included) until the chain ends.
+        def gql_cause(e)
+          cause = unwrap_optional(e.try(:gql_cause))
+          cause && mapped_exception(cause)
         end
 
         def unwrap_optional(v)
@@ -139,6 +150,8 @@ module Neo4j
             Neo4j::Driver::Exceptions::SessionExpiredException
           when TransientException
             Neo4j::Driver::Exceptions::TransientException
+          when Neo4jException # base — catches plain GQL-cause exceptions (must be last)
+            Neo4j::Driver::Exceptions::Neo4jException
           else
             nil
           end

--- a/lib/jruby/neo4j/driver/ext/exception_mapper.rb
+++ b/lib/jruby/neo4j/driver/ext/exception_mapper.rb
@@ -74,11 +74,11 @@ module Neo4j
           {
             code: effective_code(e),
             suppressed: suppressed(e),
-            gql_status: unwrap_optional(e.try(:gql_status)),
-            status_description: unwrap_optional(e.try(:status_description)),
-            classification: unwrap_optional(e.try(:classification))&.to_s,
-            raw_classification: unwrap_optional(e.try(:raw_classification)),
-            diagnostic_record: unwrap_optional(e.try(:diagnostic_record))&.to_h,
+            gql_status: unwrap_optional(e.gql_status),
+            status_description: unwrap_optional(e.status_description),
+            classification: unwrap_optional(e.classification)&.to_s,
+            raw_classification: unwrap_optional(e.raw_classification),
+            diagnostic_record: unwrap_optional(e.diagnostic_record)&.to_h,
             gql_cause: gql_cause(e)
           }
         end
@@ -88,7 +88,7 @@ module Neo4j
         # asserts on. Each cause is itself a Neo4jException, so mapped_exception
         # recurses (its own gqlCause included) until the chain ends.
         def gql_cause(e)
-          cause = unwrap_optional(e.try(:gql_cause))
+          cause = unwrap_optional(e.gql_cause)
           cause && mapped_exception(cause)
         end
 

--- a/lib/shared/neo4j/driver/exceptions/neo4j_exception.rb
+++ b/lib/shared/neo4j/driver/exceptions/neo4j_exception.rb
@@ -5,12 +5,12 @@ module Neo4j
     module Exceptions
       class Neo4jException < RuntimeError
         attr_reader :code, :suppressed, :gql_status, :status_description,
-                    :classification, :raw_classification, :diagnostic_record
+                    :classification, :raw_classification, :diagnostic_record, :gql_cause
 
         def initialize(message = nil, code: nil, suppressed: nil,
                        gql_status: nil, status_description: nil,
                        classification: nil, raw_classification: nil,
-                       diagnostic_record: nil)
+                       diagnostic_record: nil, gql_cause: nil)
           super(message)
           @code = code
           @suppressed = Array(suppressed)
@@ -19,6 +19,7 @@ module Neo4j
           @classification = classification
           @raw_classification = raw_classification
           @diagnostic_record = diagnostic_record
+          @gql_cause = gql_cause
         end
 
         def add_suppressed(*exceptions)

--- a/testkit-backend/responses/driver_error.rb
+++ b/testkit-backend/responses/driver_error.rb
@@ -13,9 +13,10 @@ module TestkitBackend
           code: @object.try(:code),
           gqlStatus: @object.try(:gql_status),
           statusDescription: @object.try(:status_description),
-          diagnosticRecord: diagnostic_record_data,
-          classification: @object.try(:classification)&.to_s,
+          diagnosticRecord: diagnostic_record_data(@object),
+          classification: classification_of(@object),
           rawClassification: @object.try(:raw_classification),
+          cause: gql_error(@object.try(:gql_cause)),
           retryable: @object.is_a?(Neo4j::Driver::Exceptions::TransientException) ||
                      @object.is_a?(Neo4j::Driver::Exceptions::ServiceUnavailableException) ||
                      @object.is_a?(Neo4j::Driver::Exceptions::SecurityRetryableException) ||
@@ -27,11 +28,35 @@ module TestkitBackend
 
       private
 
+      # A nested GQL error in the cause chain (testkit's DriverError.cause is
+      # a GqlError). Same GQL fields as the top error minus the driver-level
+      # ones (no id/errorType/code/retryable), recursing through its own
+      # gql_cause. nil when the exception has no GQL cause.
+      def gql_error(exc)
+        return unless exc
+
+        named_entity('GqlError', **{
+          gqlStatus: exc.try(:gql_status),
+          statusDescription: exc.try(:status_description),
+          msg: exc.message,
+          diagnosticRecord: diagnostic_record_data(exc),
+          classification: classification_of(exc),
+          rawClassification: exc.try(:raw_classification),
+          cause: gql_error(exc.try(:gql_cause))
+        }.compact)
+      end
+
+      # testkit always wants a classification string; like Java's backend
+      # (orElse "UNKNOWN") an absent/unrecognised one maps to "UNKNOWN".
+      def classification_of(exc)
+        exc.try(:classification)&.to_s || 'UNKNOWN'
+      end
+
       # diagnostic_record is a Map<String, Value> on the wire. Encode
       # each value through Conversion.to_testkit so testkit gets
       # CypherString/Int/etc. tags.
-      def diagnostic_record_data
-        rec = @object.try(:diagnostic_record)
+      def diagnostic_record_data(exc)
+        rec = exc.try(:diagnostic_record)
         return nil unless rec
 
         rec.to_h { |k, v| [k.to_s, self.class.to_testkit(v.respond_to?(:as_ruby_object) ? v.as_ruby_object : v)] }


### PR DESCRIPTION
## Why

testkit's `errors` suite (Bolt 5.6/5.7) asserts on the nested **`cause`** (the GQL error chain) and a non-null **`classification`**. We sent neither, so on JRuby:
- the `TestError5x7` `as_cause=True` subtests crashed — `AttributeError: 'NoneType' … gql_status` (no `cause` on the wire),
- the classification subtests failed — `None != "UNKNOWN"`.

## Change

- **`gql_cause`**: expose `Neo4jException#gqlCause` on the mapped exception, mapped **recursively**; also map the base `Neo4jException` so plain GQL-cause exceptions become Ruby exceptions instead of a Java passthrough (which left an unwrapped `Optional`).
- **Backend `DriverError`**: serialize a recursive `cause` as a `GqlError` (mirroring Java's `mapToGqlError(gqlCause)`), and default `classification` to `"UNKNOWN"` like Java's backend (`orElse`).

## Result

`tests.stub.errors.test_errors` on JRuby: **2→7 pass, 16→0 error, 10→0 fail**. No regressions locally (summary 102/0, authorization 76/0, unit spec 3/0). Backend changes are flavor-agnostic; the classification default matches Java's wire behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated exception handling to recognize base Neo4j driver exceptions and map GraphQL cause chains correctly.
  * Added support for exposing `gql_cause` so nested causes are available for diagnostics.
  * Enhanced error output to include full diagnostic records (including nested cause details) to improve troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->