### PR TITLE
Advertise Feature:API:RetryableExceptions on JRuby

### DIFF
--- a/.github/testkit-stub-baseline-jruby.txt
+++ b/.github/testkit-stub-baseline-jruby.txt
@@ -136,6 +136,7 @@ Stub tests::test_error_on_rollback_using_tx_run (tests.stub.authorization.test_a
 Stub tests::test_error_on_rollback_using_tx_run (tests.stub.authorization.test_auth_token_manager.TestAuthTokenManager5x1.test_error_on_rollback_using_tx_run)
 Stub tests::test_error_on_run_using_tx_run (tests.stub.authorization.test_auth_token_manager.TestAuthTokenManager5x0.test_error_on_run_using_tx_run)
 Stub tests::test_error_on_run_using_tx_run (tests.stub.authorization.test_auth_token_manager.TestAuthTokenManager5x1.test_error_on_run_using_tx_run)
+Stub tests::test_error_retryable (tests.stub.errors.test_errors.TestError5x7.test_error_retryable)
 Stub tests::test_execute_query (tests.stub.driver_parameters.telemetry.test_telemetry.TestTelemetry.test_execute_query)
 Stub tests::test_execute_query (tests.stub.driver_parameters.telemetry.test_telemetry.TestTelemetryRouting.test_execute_query)
 Stub tests::test_execute_query_pipelines_begin (tests.stub.optimizations.test_optimizations.TestOptimizations.test_execute_query_pipelines_begin)

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -93,7 +93,7 @@ module TestkitBackend
         'Feature:API:Result.Peek'                           => 'jar',
         'Feature:API:Result.Single'                         => 'jar',
         'Feature:API:Result.SingleOptional'                 => '',
-        'Feature:API:RetryableExceptions'                   => 'a',
+        'Feature:API:RetryableExceptions'                   => 'ja',
         'Feature:API:Session:AuthConfig'                    => 'jar',
         'Feature:API:Session:NotificationsConfig'           => 'a',
         'Feature:API:SSLClientCertificate'                  => 'ja', # JRuby: ClientCertificateManager via DriverFactory; MRI mTLS not wired


### PR DESCRIPTION
## What

Advertises `Feature:API:RetryableExceptions` on the JRuby flavour. The feature gates testkit assertions on `DriverError#retryable`.

## Why it's pure advertisement

JRuby already classifies retryability correctly:
- the exception mapper maps `Neo.TransientError.*` → `TransientException` and `Neo.ClientError.*` → `ClientException`
- `driver_error.rb` already derives `retryable` from the mapped class (`TransientException` / `ServiceUnavailableException` / `SecurityRetryableException` / `AuthorizationExpiredException`)

So no driver or backend code change was needed — only the feature flag.

## Verification (local, JRuby)

- `stub.errors`: 8/8, including the now-active `TestError5x7.test_error_retryable` (`Neo.TransientError.Oopsie.OhSnap` → retryable, `Neo.ClientError.User.Uncool` → not) and the inline retryable check in `TestError5x6.test_error`.
- `stub.authorization`: 113 ran, 0 fail / 0 error — the `_assert_retryable` / `_assert_not_retryable` helpers (no-ops without the feature) now assert and hold across all version classes.

## Changes

- `get_features.rb`: `Feature:API:RetryableExceptions` `'a'` → `'ja'`
- `testkit-stub-baseline-jruby.txt`: +1 newly-passing method-level test

MRI is unaffected — not advertised there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled retryable exceptions functionality for JRuby platform.
  * Updated test baseline configuration to reflect platform-specific feature support changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->