### PR TITLE
Move BookmarkManager spec to shared (passes on MRI too)

### DIFF
--- a/spec/shared/integration/bookmark_manager_spec.rb
+++ b/spec/shared/integration/bookmark_manager_spec.rb
@@ -2,8 +2,7 @@
 
 # Exercises the common BookmarkManager API — BookmarkManagers.default_manager
 # plus session(bookmark_manager:) — in Ruby terms only (Set, Bookmark#value).
-# Lives under spec/jruby for now only because MRI has not implemented the
-# feature yet; the assertions are impl-agnostic and should hold on MRI too.
+# Impl-agnostic, so it runs on both flavors.
 RSpec.describe 'BookmarkManager' do
   it 'tracks bookmarks across sessions and notifies the consumer on commit' do
     consumed = nil


### PR DESCRIPTION
## What

Moves `bookmark_manager_spec` from `spec/jruby/integration/` to `spec/shared/integration/`, so it runs on **both** flavors.

## Why

It only lived under `spec/jruby` because MRI hadn't implemented BookmarkManager when it was written (the file's own comment said as much). MRI now supports `BookmarkManagers.default_manager` (`bookmarks_consumer` / `initial_bookmarks` / `bookmarks_supplier`) and `session(bookmark_manager:)`, and the assertions are impl-agnostic Ruby (`Set`, `Bookmark#value`).

Verified **3 examples, 0 failures** on both JRuby and MRI.

## What stays jruby-only

`spec/jruby/integration/logging_spec.rb` is **not** moved: MRI's pure-Ruby driver emits nothing through a supplied logger — `GraphDatabase.driver(logger:)` produces **0** `logger.add` calls on MRI, so the spec's "records debug and trace info" assertion (`add` ≥ twice) only holds on JRuby. (`exception_mapper_spec.rb` is likewise inherently JRuby — it tests the Java→Ruby `Ext::ExceptionMapper`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated integration spec documentation to explicitly clarify that the specs run on both MRI and JRuby.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->