### PR TITLE
docs: pipeline-first Bolt::Connection design (driver-owned reactor)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -141,14 +141,15 @@ conformance suite assume; we're paying the interest now.
 Decision: make `Bolt::Connection` fully read/write independent via a
 **driver-owned `Async` reactor**, from day one — true independence, not a
 pull-driven interim (deferred debt again). The driver owns one reactor thread;
-all connection IO (read+write) are fibers on it; each connection has a
+all connection IO (read+write) runs as fibers on it; each connection has a
 long-lived reader fiber that drains responses for the connection's whole life
 (incl. idle in the pool). `send_message` enqueues `(message, handler)` on a FIFO
-and returns a future; the reader fiber completes futures (SUCCESS/FAILURE/
-IGNORED) / buffers RECORDs, in request order. Callers bridge in via the Ruby 3.2
+and returns a result mailbox (a stdlib scheduler-aware `Thread::Queue`/
+`ConditionVariable`, not concurrent-ruby's Future); the reader fiber resolves
+mailboxes (SUCCESS/FAILURE/IGNORED) / buffers RECORDs, in request order. Callers bridge in via the Ruby 3.2
 scheduler-aware `Queue`/`Mutex`/`ConditionVariable`: under a Fiber scheduler
 (Falcon) the caller fiber yields (async for free); without one (Puma/sync) the
-caller thread blocks and the reactor completes its future cross-thread (the
+caller thread blocks and the reactor resolves its mailbox cross-thread (the
 scheduler's `unblock` hook is thread-safe).
 
 Why driver-owned, not per-caller: **fibers can't cross threads** (FiberError),

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -128,3 +128,44 @@ with a *hypothetical unshaded JRuby build* too: consume a duck-typed
 metrics object (`connection_pool_metrics` → items responding to
 `id`/`in_use`/`idle`), and match the requested address by parsing `id`
 as `"host:port-…"`, mirroring Java's `GetConnectionPoolMetrics`.
+
+## 2026-06-19 — MRI Bolt::Connection goes pipeline-first
+
+The synchronous send-then-read connection model is a wall: HELLO+LOGON
+pipelining (recv-timeout), pipelined RESET-on-release (MinimalResets / the 5
+drop_connections tests), PullPipelining/AuthPipelining/ExecuteQueryPipelining,
+and the router-liveness interaction all stall on it. The earlier "async is
+overengineering / YAGNI" call deferred the foundation the Bolt protocol and the
+conformance suite assume; we're paying the interest now.
+
+Decision: make `Bolt::Connection` fully read/write independent via a
+**driver-owned `Async` reactor**, from day one — true independence, not a
+pull-driven interim (deferred debt again). The driver owns one reactor thread;
+all connection IO (read+write) are fibers on it; each connection has a
+long-lived reader fiber that drains responses for the connection's whole life
+(incl. idle in the pool). `send_message` enqueues `(message, handler)` on a FIFO
+and returns a future; the reader fiber completes futures (SUCCESS/FAILURE/
+IGNORED) / buffers RECORDs, in request order. Callers bridge in via the Ruby 3.2
+scheduler-aware `Queue`/`Mutex`/`ConditionVariable`: under a Fiber scheduler
+(Falcon) the caller fiber yields (async for free); without one (Puma/sync) the
+caller thread blocks and the reactor completes its future cross-thread (the
+scheduler's `unblock` hook is thread-safe).
+
+Why driver-owned, not per-caller: **fibers can't cross threads** (FiberError),
+but pooled connections are borrowed across threads — so a reader fiber must have
+one stable home or the shared pool breaks. Single-threaded reactor IO is also
+TLS-safe (no concurrent SSL_read/SSL_write). Scalable for MRI: the GVL already
+serializes parsing onto one core, so the reactor centralizes already-serialized
+work with less overhead than thread-per-connection; scale past one core via
+processes (Falcon/Puma workers), not more reactor threads.
+
+Empirically validated on Ruby 3.4.9 / async 2.39.0 (`docs/async_spike.rb`):
+cross-thread fiber resume raises FiberError; SSLSocket#read yields under the
+scheduler; a non-scheduler thread woke a reactor fiber on a Thread::Queue and got
+a result back. Sequence in validated slices: (1) reactor/handler/futures
+machinery proven on HELLO+LOGON + recv-timeout; (2) pipelined dirty-connection
+RESET → real MinimalResets (the 5 drop_connections tests); (3) a *narrow*
+router-liveness trigger; (4) PullPipelining / AuthPipelining /
+ExecuteQueryPipelining. Full design: `docs/pipelined-connection.md`. Do NOT keep
+nibbling symptoms — per-op home-db re-route regressed default-db reads; eager
+reset-on-release timed out the suite.

--- a/docs/async_spike.rb
+++ b/docs/async_spike.rb
@@ -1,0 +1,39 @@
+require 'async'
+require 'socket'
+require 'openssl'
+
+# self-signed cert
+key  = OpenSSL::PKey::RSA.new(2048)
+cert = OpenSSL::X509::Certificate.new
+cert.subject = cert.issuer = OpenSSL::X509::Name.parse('/CN=localhost')
+cert.not_before = Time.now; cert.not_after = Time.now + 3600
+cert.public_key = key.public_key; cert.serial = 1; cert.version = 2
+cert.sign(key, OpenSSL::Digest.new('SHA256'))
+
+tcp = TCPServer.new('127.0.0.1', 0); port = tcp.addr[1]
+sctx = OpenSSL::SSL::SSLContext.new; sctx.cert = cert; sctx.key = key
+ssl_server = OpenSSL::SSL::SSLServer.new(tcp, sctx)
+srv = Thread.new { c = ssl_server.accept; sleep 1.0; c.write('hello'); c.close rescue nil }
+
+out = []
+Async do |task|
+  r = task.async do
+    cctx = OpenSSL::SSL::SSLContext.new; cctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    s = OpenSSL::SSL::SSLSocket.new(TCPSocket.new('127.0.0.1', port), cctx); s.connect
+    t0 = Time.now; data = s.read(5)
+    out << "  ssl.read => #{data.inspect} after #{(Time.now - t0).round(2)}s"
+  end
+  t = task.async { 4.times { |i| sleep 0.2; out << "  tick #{i}" } }
+  r.wait; t.wait
+end
+srv.join
+puts "TEST A — SSL read under async scheduler (ticks interleaving the 1s read = SSL yielded):"
+puts out
+
+puts "TEST B — cross-thread unblock (main thread submits into a driver-owned reactor):"
+work = Thread::Queue.new; done = Thread::Queue.new
+rt = Thread.new { Async { |task| task.async { loop { j = work.pop; break if j == :stop; done.push(j * 2) } }.wait } }
+work.push(21)                 # pushed from main thread (no scheduler)
+res = done.pop
+puts "  main pushed 21 -> reactor fiber returned #{res}"
+work.push(:stop); rt.join

--- a/docs/async_spike.rb
+++ b/docs/async_spike.rb
@@ -37,3 +37,17 @@ work.push(21)                 # pushed from main thread (no scheduler)
 res = done.pop
 puts "  main pushed 21 -> reactor fiber returned #{res}"
 work.push(:stop); rt.join
+
+# TEST C — a fiber cannot be resumed from another thread (why a shared pool
+# can't put reader fibers on per-caller reactors): forces a driver-owned reactor.
+puts "TEST C — fiber resume across threads:"
+f = Fiber.new { Fiber.yield; :done }
+f.resume
+Thread.new do
+  begin
+    f.resume
+    puts "  resumed cross-thread (unexpected!)"
+  rescue => e
+    puts "  cross-thread resume -> #{e.class}: #{e.message}"
+  end
+end.join

--- a/docs/pipelined-connection.md
+++ b/docs/pipelined-connection.md
@@ -1,0 +1,162 @@
+# MRI Bolt::Connection — pipeline-first refactor
+
+Status: **proposed** (2026-06-19). Kickoff design for a fresh session. See the
+`mri-needs-pipelined-connection` memory for the why and the symptom→root map,
+and `DECISIONS.md` for the dated decision.
+
+## The problem
+
+MRI's `Bolt::Connection` is **synchronous send-then-read**: nearly every call
+site does `send_message(x); flush; fetch_response`. Outbound bytes are written
+per message (`send_message` → `write_chunk`), and `@response_queue << :pending`
+already tracks each in-flight response — but the *reads* happen eagerly, one
+right after each send. The Bolt protocol and the testkit conformance suite
+assume the opposite: a **pipelined** peer that can send a batch of messages and
+read the responses lazily, in order.
+
+Every hard feature that has stalled traces to this one gap:
+
+- **recv-timeout (Liveness):** `liveness_check_recv_timeout.script` is
+  `C: HELLO  C: LOGON  S: SUCCESS  S: SUCCESS` — the stub answers only after it
+  has **both** messages. MRI sends HELLO and *reads* before sending LOGON →
+  deadlock.
+- **MinimalResets / the 5 `drop_connections` tests:** MRI's only reset is a
+  synchronous RESET round-trip. Eager reset-on-release timed out the whole stub
+  suite. Java marks the connection dirty and **pipelines** the RESET ahead of
+  the next use, reading its reply lazily.
+- **Optimization:PullPipelining (~100 routing tests):** only works by accident
+  today — `Session#run`/`Transaction#run` queue RUN+PULL then flush. The one
+  place the pipelined shape leaks through, undeclared.
+- **Optimization:AuthPipelining / ExecuteQueryPipelining** (`ja`, MRI blank):
+  same root.
+
+## Current model (what exists)
+
+- `send_message(msg)`: packs + writes the chunk to `@socket`, pushes `:pending`
+  onto `@response_queue`.
+- `flush`: flushes the socket write buffer.
+- `fetch_response`: reads one response, pops one `:pending`.
+- `send_all(*msgs)`: sends each + one flush (building block, already present).
+- Call sites interleave: `send X; flush; read X; send Y; flush; read Y`.
+
+So the **spine** (an ordered queue of in-flight responses) is already there. The
+refactor is a *discipline change* at the call sites + the handshake, not a
+ground-up rewrite.
+
+## Target model — driver-owned reactor, fiber readers, bridged callers
+
+Decided 2026-06-19 (with the user) and **empirically validated** on Ruby 3.4.9 /
+async 2.39.0 (`docs/async_spike.rb`). Reads and writes are fully independent —
+not a pull-driven degrade — in every host.
+
+**The driver owns one `Async` reactor thread.** All connection IO (read *and*
+write) runs as fibers on it. Each connection has a long-lived **reader fiber**
+that drains responses for the whole connection lifetime — including while the
+connection sits idle in the pool, so a server keepalive/close is noticed
+independently of any request.
+
+The spine is a FIFO queue of `(message, response handler)` pairs:
+
+- `send_message` enqueues `(message, handler)` and returns a **future**.
+- The reader fiber loops: read one response, pop the front handler, complete its
+  future (`SUCCESS` / `FAILURE` / `IGNORED`) or feed a `RECORD` into the owning
+  `Result`'s buffer. Bolt responses arrive in request order → front-of-queue
+  dispatch is correct.
+- A caller blocks on its future when it needs the value.
+
+**Callers bridge in via scheduler-aware primitives** (`Queue` / `Mutex` /
+`ConditionVariable`, made fiber-aware in Ruby 3.2):
+
+- Under a **Fiber scheduler** (Falcon, or any `Async {}`): the caller fiber
+  yields while waiting → the host reactor runs other requests. Async for free.
+- **Without** a scheduler (Puma threads, bare scripts): the caller thread
+  blocks on the future; the driver's reactor completes it cross-thread — the
+  scheduler's `unblock` hook is thread-safe (validated: a non-scheduler thread
+  woke a reactor fiber parked on a `Thread::Queue` and got a result back).
+
+### Why driver-owned (not per-caller) reactor
+
+- **Fibers can't cross threads** (`FiberError: fiber called across threads`,
+  verified). Connections are pooled and borrowed by sessions on different
+  threads/fibers. A reader fiber pinned to caller-thread A's reactor cannot be
+  driven when thread B borrows that connection. Per-caller reactors would force
+  per-thread pools (no sharing → up to N×threads more server connections, and a
+  long-lived reactor per thread anyway). One driver-owned reactor keeps a single
+  shared pool coherent.
+- **TLS-safe.** A single reactor thread serializes each socket's read+write
+  cooperatively → never a concurrent `SSL_read`/`SSL_write` on one `SSLSocket`
+  (which OpenSSL is not safe for). And `SSLSocket#read` *yields* under the
+  scheduler (validated: a 1s TLS read let other fibers run), so it doesn't
+  freeze the reactor.
+
+### Scalability
+
+One reactor per driver **per process** is the right granularity for MRI, not a
+bottleneck: the GVL already serializes all Ruby parsing onto one core, so a
+thread-per-connection model is single-core for deserialization too — the reactor
+just centralizes that already-serialized work with *less* overhead (no GVL
+contention, cheap fiber switches, one `epoll`/`kqueue` wait vs N blocked
+threads). Multiplexing ~100 pooled sockets is trivial for an event loop. Scale
+past one core the standard Ruby way — **more processes** (Puma/Falcon workers,
+each with its own driver+reactor); more reactor *threads* in one process
+wouldn't help (GVL). Discipline: keep CPU-heavy/user code *off* the reactor
+(hand records back to the caller); the reactor does only IO + bounded per-message
+parse + future completion.
+
+### Considerations (the substance of slice 1)
+
+- **Thread-safety** of the handler queue and connection state (the cross-thread
+  bridge is the only multi-thread surface; everything else is reactor-local).
+- **RECORD streaming:** the reader feeds records into a buffer the consumer reads
+  from; backpressure (PULL `n`) is the reader's concern.
+- **Failure fan-out:** a dead socket / read timeout fails **all** pending futures
+  and marks the connection dead.
+- **Clean shutdown:** closing a connection / stopping the driver must unblock the
+  reader and tear down the reactor thread without leaking.
+- **recv-timeout:** `IO#timeout` (scheduler-aware) on the reader; timeout while
+  reads are pending fails them, while idle it is a keepalive signal.
+
+## Slice sequencing (each its own validation pass)
+
+1. **Reader-thread + handler-queue + futures machinery, proven on HELLO+LOGON.**
+   This is the foundation, not a localized reorder: stand up the per-connection
+   reader thread, the mutex-guarded `(message, handler)` FIFO, futures, RECORD
+   buffering, failure fan-out and clean shutdown. Exercise it first on the
+   handshake (send HELLO+LOGON, then the reader drains both) and on a basic
+   RUN/PULL. Combine with the `connection.recv_timeout_seconds` socket timeout to
+   close the recv-timeout liveness test. Re-run the **full** stub suite — this
+   touches every operation, so the regression bar is the whole suite, green.
+2. **Pipelined dirty-connection RESET** → real `OPTIMIZATION:MinimalResets`.
+   MRI already passes the two MinimalResets *gate* tests (`test_no_reset_on_
+   clean_connection`, `test_exactly_one_reset_on_failure`) for clean connections;
+   the work is aligning the **error/retry path** so advertising MinimalResets
+   doesn't break `test_should_not_retry_non_retryable_tx_failures` (×2). Then
+   advertise it → the 5 `drop_connections` tests pass (they need the metrics WIP
+   already on this branch).
+3. **Router liveness** (the 2 `test_timeout*` routing tests) — a *narrow*
+   trigger, NOT the blanket per-op home-db re-route that regressed
+   `test_should_read_..._default_db`. Guard with that default-db test.
+4. **Pipelining optimizations** — PullPipelining (~100), then AuthPipelining /
+   ExecuteQueryPipelining, fall out of the formalized model.
+
+## Constraints / guardrails
+
+- Don't flip `get_features.rb` flags to grab skipped tests; advertise a flag
+  only when its whole cluster genuinely passes (`no-new-feature-advertising`).
+- Validate every slice against the testkit stub suite locally with the **rust**
+  boltstub on the **MRI** flavor before expanding (`local-tls-testing` /
+  `local-boltstub-debug-loop` memories; ruby-3.4.9 via rvm). The full suite is
+  the regression guard — eager reset-on-release proved a per-release round-trip
+  is unacceptable (it timed the suite out).
+- Already done and parked on `fix/mri-liveness-check-routing`:
+  `Driver#metrics` + per-address `idle`/`in_use` (commit "wip(mri):
+  connection-pool metrics infrastructure"). Reusable by slice 2.
+
+## Validation loop
+
+```
+TEST_NEO4J_URL=bolt://localhost:7687  # for integration; stub needs no server
+TEST_RUSTY_STUB=true \
+  bin/run-testkit tests.stub.<module>   # rust boltstub, MRI flavor (rvm ruby-3.4.9)
+bundle exec rspec spec/mri spec/shared/neo4j
+```

--- a/docs/pipelined-connection.md
+++ b/docs/pipelined-connection.md
@@ -1,8 +1,8 @@
 # MRI Bolt::Connection — pipeline-first refactor
 
-Status: **proposed** (2026-06-19). Kickoff design for a fresh session. See the
-`mri-needs-pipelined-connection` memory for the why and the symptom→root map,
-and `DECISIONS.md` for the dated decision.
+Status: **proposed** (2026-06-19). Kickoff design for a fresh session. The
+why and the symptom→root map are in "The problem" below; `DECISIONS.md` has the
+dated decision.
 
 ## The problem
 
@@ -47,7 +47,7 @@ ground-up rewrite.
 
 Decided 2026-06-19 (with the user) and **empirically validated** on Ruby 3.4.9 /
 async 2.39.0 (`docs/async_spike.rb`). Reads and writes are fully independent —
-not a pull-driven degrade — in every host.
+not a pull-driven degradation — in every host.
 
 **The driver owns one `Async` reactor thread.** All connection IO (read *and*
 write) runs as fibers on it. Each connection has a long-lived **reader fiber**
@@ -57,12 +57,18 @@ independently of any request.
 
 The spine is a FIFO queue of `(message, response handler)` pairs:
 
-- `send_message` enqueues `(message, handler)` and returns a **future**.
+- `send_message` enqueues `(message, handler)` and returns a **result mailbox**
+  — concretely a stdlib `Thread::Queue` (one-shot) or `Mutex`+`ConditionVariable`,
+  *not* `concurrent-ruby`'s `Future`. These are the Ruby-3.2 scheduler-aware
+  primitives: they block a plain caller thread *and* yield a fiber under a
+  scheduler, so the same handle works in both worlds (`Async::Variable`/
+  `Async::Condition` are the in-reactor idiom, but can't be awaited from a
+  non-scheduler caller thread, which is why the mailbox is stdlib).
 - The reader fiber loops: read one response, pop the front handler, complete its
-  future (`SUCCESS` / `FAILURE` / `IGNORED`) or feed a `RECORD` into the owning
+  mailbox (`SUCCESS` / `FAILURE` / `IGNORED`) or feed a `RECORD` into the owning
   `Result`'s buffer. Bolt responses arrive in request order → front-of-queue
   dispatch is correct.
-- A caller blocks on its future when it needs the value.
+- A caller blocks on its mailbox when it needs the value.
 
 **Callers bridge in via scheduler-aware primitives** (`Queue` / `Mutex` /
 `ConditionVariable`, made fiber-aware in Ruby 3.2):
@@ -70,7 +76,7 @@ The spine is a FIFO queue of `(message, response handler)` pairs:
 - Under a **Fiber scheduler** (Falcon, or any `Async {}`): the caller fiber
   yields while waiting → the host reactor runs other requests. Async for free.
 - **Without** a scheduler (Puma threads, bare scripts): the caller thread
-  blocks on the future; the driver's reactor completes it cross-thread — the
+  blocks on the mailbox; the driver's reactor completes it cross-thread — the
   scheduler's `unblock` hook is thread-safe (validated: a non-scheduler thread
   woke a reactor fiber parked on a `Thread::Queue` and got a result back).
 
@@ -101,7 +107,7 @@ past one core the standard Ruby way — **more processes** (Puma/Falcon workers,
 each with its own driver+reactor); more reactor *threads* in one process
 wouldn't help (GVL). Discipline: keep CPU-heavy/user code *off* the reactor
 (hand records back to the caller); the reactor does only IO + bounded per-message
-parse + future completion.
+parse + mailbox completion.
 
 ### Considerations (the substance of slice 1)
 
@@ -109,7 +115,7 @@ parse + future completion.
   bridge is the only multi-thread surface; everything else is reactor-local).
 - **RECORD streaming:** the reader feeds records into a buffer the consumer reads
   from; backpressure (PULL `n`) is the reader's concern.
-- **Failure fan-out:** a dead socket / read timeout fails **all** pending futures
+- **Failure fan-out:** a dead socket / read timeout resolves **all** pending mailboxes
   and marks the connection dead.
 - **Clean shutdown:** closing a connection / stopping the driver must unblock the
   reader and tear down the reactor thread without leaking.
@@ -118,9 +124,10 @@ parse + future completion.
 
 ## Slice sequencing (each its own validation pass)
 
-1. **Reader-thread + handler-queue + futures machinery, proven on HELLO+LOGON.**
+1. **Reactor + reader-fiber + handler-queue + mailbox machinery, proven on HELLO+LOGON.**
    This is the foundation, not a localized reorder: stand up the per-connection
-   reader thread, the mutex-guarded `(message, handler)` FIFO, futures, RECORD
+   driver-owned reactor, the per-connection reader fiber, the mutex-guarded
+   `(message, handler)` FIFO, result mailboxes, RECORD
    buffering, failure fan-out and clean shutdown. Exercise it first on the
    handshake (send HELLO+LOGON, then the reader drains both) and on a basic
    RUN/PULL. Combine with the `connection.recv_timeout_seconds` socket timeout to
@@ -142,10 +149,10 @@ parse + future completion.
 ## Constraints / guardrails
 
 - Don't flip `get_features.rb` flags to grab skipped tests; advertise a flag
-  only when its whole cluster genuinely passes (`no-new-feature-advertising`).
+  only when its whole cluster genuinely passes.
 - Validate every slice against the testkit stub suite locally with the **rust**
-  boltstub on the **MRI** flavor before expanding (`local-tls-testing` /
-  `local-boltstub-debug-loop` memories; ruby-3.4.9 via rvm). The full suite is
+  boltstub on the **MRI** flavor before expanding (ruby-3.4.9 via rvm; see
+  `DEVELOPMENT.md` and the `bin/run-testkit` header). The full suite is
   the regression guard — eager reset-on-release proved a per-release round-trip
   is unacceptable (it timed the suite out).
 - Already done and parked on `fix/mri-liveness-check-routing`:


### PR DESCRIPTION
## What

Design + dated decision for the architectural refactor behind the stalled
`Liveness.Check` / `MinimalResets` / recv-timeout / pipelining work: move MRI's
`Bolt::Connection` from **synchronous send-then-read** to a **driver-owned
`Async` reactor** with fiber readers and bridged callers.

**Docs only — no code changes.**

- **`docs/pipelined-connection.md`** — current→target model; the handler-queue +
  futures spine; *why driver-owned, not per-caller* (fibers can't cross threads,
  but pooled connections are borrowed across them); TLS-safety; scalability (the
  GVL serialises parsing on one core → scale via processes, not reactor threads);
  slice sequencing (HELLO+LOGON first) and the validation loop.
- **`docs/async_spike.rb`** — the experiment, kept in-repo as durable evidence.
- **`DECISIONS.md`** — dated decision entry.

## Why now

Three full features stalled on the synchronous model (recv-timeout deadlocks on
`HELLO+LOGON`; `MinimalResets`/drop-connections need pipelined RESET;
`PullPipelining`/`AuthPipelining`/`ExecuteQueryPipelining` are the same root).
This captures the agreed foundation so the work starts from a validated design
rather than re-deriving it.

## Validated (Ruby 3.4.9 / async 2.39.0, `docs/async_spike.rb`)

- Cross-thread fiber resume → `FiberError` (forces a driver-owned reactor for a
  shared pool).
- `SSLSocket#read` yields under the Fiber scheduler (the historically rough TLS
  path — it works).
- A non-scheduler thread woke a reactor fiber on a `Thread::Queue` and got a
  result back (the synchronous→reactor bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural decision log and design documentation for connection handling improvements, outlining plans for enhanced performance and reliability features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->