### PR TITLE
feat(mri): promote public streaming path onto the prefetch pump

### DIFF
--- a/docs/sans-io-pump.md
+++ b/docs/sans-io-pump.md
@@ -106,13 +106,48 @@ acquire re-resolves + reconnects. No RESET round-trip (unlike the liveness
 probe), NOOP keepalives are drained harmlessly. This gives full parity with the
 reactor branch on that test.
 
+## Wiring the prefetch pump into the live streaming path
+
+`Result` drives the pump via **lazy promotion**, so the pump only ever runs when
+it actually helps (a multi-batch stream) and single-batch results keep the
+zero-overhead synchronous path:
+
+- **Batch 1 is synchronous.** Its `PULL` is already pipelined with `RUN`, so the
+  cursor drains the first batch on the caller's thread exactly as before. No pump.
+- **First `has_more` ⇒ promote.** `Result#on_success` builds a `RecordBuffer` +
+  `RecordSource`, sends batch 2's `PULL`, and `Executor.spawn`s a `Bolt::Pump`
+  for batches 2..N (a fiber under a host scheduler, else a thread). From then on
+  the pump is the connection's **sole reader/writer**; the cursor only touches
+  the buffer (`@buffer.shift`), so there's no concurrent socket access. The pump
+  prefetches batch *k+1* while the consumer drains batch *k*.
+- **One worker per paginating stream, spanning all pages** — not per page, and
+  never for a single-batch result. It exits at the terminal; the cursor `join`s
+  it before releasing the connection so a reused connection can't get a stray
+  reader.
+- **`consume()` cancels via the pump:** `Pump#cancel` flags the buffer; at the
+  next batch boundary the pump sends `DISCARD {n:-1}` and reads on to the
+  terminating `SUCCESS` (summary/bookmark preserved), so the connection stays
+  reusable. Cancelling during batch 1 (pre-promotion) keeps the old inline
+  `DISCARD`.
+- **Failures** surface as a raise from `@buffer.shift`, classified by the
+  consumer (routing's `SessionExpired` swap etc.) exactly as the synchronous path.
+
+Why connection-pinned per stream (not a persistent per-connection worker): a
+result is server-side stateful and bound to its connection, so every `PULL` for
+one stream goes to that one connection. Thread create/teardown (~15µs, measured)
+is noise against the network round-trips a multi-batch stream already pays, and a
+persistent parked worker would cost ~52KB resident per pooled connection *and*
+force a parked fiber-per-connection under a reactor (which the ambient-reactor
+model avoids). So: uniform per-stream spawn, thread and fiber paths identical.
+
 ## Build order
 
-1. `Bolt::Wire` + unit tests (this commit).
-2. `Bolt::RecordBuffer` + watermark autopull.
-3. Pump + `Executor` (on-demand; Thread/fiber prefetch).
-4. Rewire `Bolt::Connection` onto the core + pump; cursor lifecycle. Preserve the
-   public `Connection` API so session/transaction/result/pool/providers are
-   untouched.
-5. Validate: full rust-boltstub stub suite on CRuby (zero regressions vs main)
-   and mri-on-jruby green; restore the mri-on-jruby CI rows.
+1. `Bolt::Wire` + unit tests. ✅
+2. `Bolt::RecordBuffer` + watermark autopull. ✅
+3. Pump + `Executor` (on-demand default; Thread/fiber prefetch). ✅
+4. Rewire `Bolt::Connection` onto the core + on-demand pump; preserve the public
+   `Connection` API so session/transaction/result/pool/providers are untouched.
+   ✅ (#396)
+5. Promote the public streaming path onto the prefetch pump (this section). ✅
+6. Validate: rust-boltstub stub suite — streaming + routing modules byte-identical
+   vs `main` locally; full CI baseline gate green on mri / mri-on-jruby / jruby.

--- a/lib/mri/neo4j/driver/bolt/executor.rb
+++ b/lib/mri/neo4j/driver/bolt/executor.rb
@@ -21,7 +21,14 @@ module Neo4j
 
         # True when a Fiber scheduler is installed on the current thread, so a
         # spawned pump will be a fiber that cooperates with the host reactor.
-        def reactor? = !Fiber.scheduler.nil?
+        #
+        # CRuby only: JRuby's Fiber-scheduler support is incomplete (no IO_Event
+        # selector; the scheduler's I/O hooks don't fire), so even when a host
+        # installs one we must not hand the pump to it — `Fiber.schedule` there
+        # fails / desyncs the stream. The mri-on-jruby flavor is thread-only by
+        # design (same reason lib/mri can't run on the async reactor under JRuby),
+        # so on JRuby we always spawn a real thread regardless of any scheduler.
+        def reactor? = RUBY_PLATFORM != 'java' && !Fiber.scheduler.nil?
 
         # Run `block` in the background-appropriate context and return a handle
         # (responds to #alive?; #join on the thread path). Under a scheduler the

--- a/lib/mri/neo4j/driver/bolt/pump.rb
+++ b/lib/mri/neo4j/driver/bolt/pump.rb
@@ -23,7 +23,6 @@ module Neo4j
           @source = source
           @buffer = buffer
           @running = false
-          @cancelled = false
         end
 
         # Run the fill loop until the stream ends, fails, or is cancelled. Any
@@ -31,25 +30,32 @@ module Neo4j
         # on its next read) — the stdlib-fiber pump propagates errors manually.
         def run
           @running = true
-          @source.next_response.accept(self) while @running && !@cancelled
+          @source.next_response.accept(self) while @running
         rescue ClosedQueueError
-          # cancel() closed the buffer while we were parked in push_record —
-          # cooperative shutdown, not a stream error. (Must precede the generic
-          # rescue: ClosedQueueError is a StandardError.)
+          # The consumer closed the buffer (fail/finish) while we were parked in
+          # push_record — cooperative shutdown, not a stream error. (Must precede
+          # the generic rescue: ClosedQueueError is a StandardError.)
         rescue StandardError => e
           @buffer.fail(e)
         end
 
-        # Cooperative cancel (cursor closed early). Ends the buffer so a pump
-        # parked in await_pull_capacity wakes; the loop stops between responses.
+        # Cooperative cancel (cursor abandoned the result early). Flags the
+        # buffer so a pump parked in await_pull_capacity wakes; on its next
+        # batch boundary it sends DISCARD instead of PULL and keeps reading
+        # until the server's terminating SUCCESS, so the connection stays
+        # reusable. The consumer drains the buffer concurrently, which also
+        # unblocks a pump parked in push_record.
         def cancel
-          @cancelled = true
-          @buffer.finish
+          @buffer.request_cancel
         end
 
         # --- Response visitor (Bolt::Message#accept dispatches here) --------
 
         def on_record(message)
+          # Once cancelled the consumer no longer wants records; drop them rather
+          # than block on the bound (the DISCARD reply still flows to on_success).
+          return if @buffer.cancelled?
+
           # push_record blocks at the buffer's bound — that block is the
           # consumer backpressure (fill no further than the high watermark).
           @buffer.push_record(message)
@@ -59,9 +65,13 @@ module Neo4j
           if message.metadata[:has_more]
             @buffer.batch_complete(has_more: true)
             # Hysteresis: wait until the buffer has drained to the low watermark
-            # before asking the server for the next batch (false ⇒ ended/cancelled).
+            # before asking the server for the next batch. false ⇒ stop PULLing:
+            # either the stream ended/failed, or the consumer cancelled — in
+            # which case DISCARD the rest and read on to the terminating SUCCESS.
             if @buffer.await_pull_capacity
               @source.pull(@buffer.fetch_size)
+            elsif @buffer.cancelled?
+              @source.discard
             else
               @running = false
             end

--- a/lib/mri/neo4j/driver/bolt/record_buffer.rb
+++ b/lib/mri/neo4j/driver/bolt/record_buffer.rb
@@ -41,6 +41,7 @@ module Neo4j
           @ended = false         # final SUCCESS consumed → no more records
           @error = nil           # stream failed; re-raised to the consumer
           @summary = nil         # terminating SUCCESS metadata
+          @cancelled = false     # consumer asked to stop early → pump should DISCARD
         end
 
         # --- Producer (pump) side -------------------------------------------
@@ -79,6 +80,16 @@ module Neo4j
           @queue.close
         end
 
+        # The consumer abandoned the result early (consume / tx end). Wake a
+        # pump parked in await_pull_capacity so it stops PULLing and asks the
+        # server to DISCARD the rest. Mutex-guarded so the flag is visible to
+        # the pump on JRuby's real threads, not just under MRI's GVL.
+        def request_cancel
+          @mutex.synchronize { @cancelled = true; @drain.broadcast }
+        end
+
+        def cancelled? = @mutex.synchronize { @cancelled }
+
         # --- Consumer (cursor) side -----------------------------------------
 
         # Next record, or nil when the stream is exhausted. Blocks (yields under
@@ -104,12 +115,13 @@ module Neo4j
         # none is in flight, and the buffer has drained to/below the low
         # watermark (hysteresis: don't refill on every freed slot, refill a
         # batch at a time). Returns true and marks a PULL in flight, or false
-        # when the stream has ended/failed/been cancelled (pump should stop).
+        # when the stream has ended/failed/been cancelled (pump should stop
+        # PULLing — on cancel it then checks cancelled? and DISCARDs instead).
         # Scheduler-aware wait, so a pump fiber yields to the host reactor.
         def await_pull_capacity
           @mutex.synchronize do
-            @drain.wait(@mutex) until @ended || @error || ready_to_pull?
-            return false if @ended || @error
+            @drain.wait(@mutex) until @ended || @error || @cancelled || ready_to_pull?
+            return false if @ended || @error || @cancelled
 
             @pull_in_flight = true
             true

--- a/lib/mri/neo4j/driver/bolt/record_source.rb
+++ b/lib/mri/neo4j/driver/bolt/record_source.rb
@@ -22,6 +22,15 @@ module Neo4j
           @connection.send_message(@connection.protocol.build_pull(n: n))
           @connection.flush
         end
+
+        # Abandon the rest of the stream (cancel path). DISCARD {n: -1} tells the
+        # server to drop all remaining records and reply with the terminating
+        # SUCCESS (carrying the summary / bookmark), keeping the connection
+        # reusable — the same message the synchronous cursor sends on consume().
+        def discard(n = -1)
+          @connection.send_message(@connection.protocol.build_discard(n: n))
+          @connection.flush
+        end
       end
     end
   end

--- a/lib/mri/neo4j/driver/result.rb
+++ b/lib/mri/neo4j/driver/result.rb
@@ -297,10 +297,19 @@ module Neo4j
       end
 
       # Materialise every remaining buffered record (used by #buffer).
+      # Classify a stream failure here, mirroring the synchronous buffer() path
+      # (whose on_failure raises classify_failure): this is only reached from
+      # buffer(), never from the self-classifying has_next?, so there's no
+      # double-classification (and classify_failure is idempotent anyway).
+      # Without it, a promoted auto-commit stream failing mid-buffer would skip
+      # routing's ServiceUnavailable→SessionExpired swap and the deactivate /
+      # on_write_failure side effects.
       def drain_buffer_into_records
         while (record = next_buffered_record)
           @records << record
         end
+      rescue StandardError => e
+        raise @connection.classify_failure(e)
       end
 
       # Abandon a promoted stream: tell the pump to DISCARD the rest, then drain

--- a/lib/mri/neo4j/driver/result.rb
+++ b/lib/mri/neo4j/driver/result.rb
@@ -31,6 +31,16 @@ module Neo4j
         @failed = false     # stream ended with a server FAILURE; connection needs RESET
         @cancelled = false  # consume() called mid-stream — server should DISCARD, not paginate
         @peeked_record = nil
+        # Prefetch promotion (set once the first batch reports has_more): a
+        # background pump drains batches 2..N off the connection into @buffer
+        # while the consumer processes the current batch. Single-batch results
+        # never promote — their lone PULL is already pipelined with RUN, so the
+        # synchronous path below is optimal and spawns nothing. See
+        # docs/sans-io-pump.md and Bolt::Pump.
+        @promoted = false
+        @buffer = nil       # Bolt::RecordBuffer once promoted
+        @pump = nil         # Bolt::Pump driving the connection
+        @pump_handle = nil  # Executor handle (Thread/Fiber) — joined before release
       end
 
       attr_reader :connection, :keys
@@ -41,12 +51,19 @@ module Neo4j
         return false if @consumed
         return true if @peeked_record
 
-        # Loop until the stream gives us a RECORD or signals end. A
-        # SUCCESS in the middle (has_more=true) triggers another PULL
-        # in on_success, so the next iteration's fetch_response reads
-        # the first record of the new batch.
-        with_record_handler(->(msg) { @peeked_record = build_record(msg) }) do
-          @connection.fetch_response.accept(self) until @consumed || @peeked_record
+        if @promoted
+          # Records now arrive from the background pump via the buffer.
+          @peeked_record = next_buffered_record
+        else
+          # Loop until the stream gives us a RECORD or signals end. A SUCCESS
+          # in the middle (has_more=true) either triggers another PULL in
+          # on_success (single batch so far) or *promotes* to the prefetch
+          # pump — in which case the loop exits and the first post-promotion
+          # record comes from the buffer.
+          with_record_handler(->(msg) { @peeked_record = build_record(msg) }) do
+            @connection.fetch_response.accept(self) until @consumed || @peeked_record || @promoted
+          end
+          @peeked_record = next_buffered_record if @promoted && @peeked_record.nil? && !@consumed
         end
         !@peeked_record.nil?
       rescue StandardError => e
@@ -119,7 +136,11 @@ module Neo4j
         # SUCCESS, instead of streaming every record into the void.
         @cancelled = true
         begin
-          drain_until_consumed { |_msg| } unless @consumed
+          if @promoted
+            cancel_via_pump unless @consumed
+          else
+            drain_until_consumed { |_msg| } unless @consumed
+          end
         ensure
           @records.clear
           @discarded = true
@@ -139,7 +160,14 @@ module Neo4j
           @peeked_record = nil
         end
 
-        drain_until_consumed { |msg| @records << build_record(msg) }
+        if @promoted
+          drain_buffer_into_records
+        else
+          drain_until_consumed { |msg| @records << build_record(msg) }
+          # on_success may have promoted mid-drain (first has_more); continue
+          # materialising the remaining batches from the buffer.
+          drain_buffer_into_records if @promoted && !@consumed
+        end
       end
 
       def none?
@@ -156,6 +184,16 @@ module Neo4j
       def discard!
         @peeked_record = nil
         @discarded = true
+        # Stop a still-running pump and wait for it to exit so its thread/fiber
+        # can't read the connection after we release it (a reused connection
+        # with a stray reader would corrupt the protocol). finish() closes the
+        # buffer, waking a pump parked in push_record (ClosedQueueError → clean
+        # exit) or await_pull_capacity (ended → stop). Normal paths drain via
+        # consume/buffer first, so the pump is already done and this is a no-op.
+        if @pump
+          @buffer.finish
+          @pump_handle&.join
+        end
         release_connection
       end
 
@@ -166,14 +204,20 @@ module Neo4j
       end
 
       def on_success(msg)
-        # has_more=true means the server still has records beyond the
-        # last PULL's batch limit. Either pull the next batch or, if
-        # consume() asked to cancel the stream, send DISCARD instead so
-        # the server stops shipping records and returns the summary.
+        # Only the *first* batch's terminal reaches here — once promoted the
+        # pump is the connection's visitor, not the Result.
+        #
+        # has_more=true means the server still has records beyond this batch.
+        # If the consumer already cancelled (consume() during batch 1), send
+        # DISCARD and stay synchronous. Otherwise promote to the prefetch pump,
+        # which streams the remaining batches into @buffer in the background.
         if msg.metadata[:has_more]
-          next_msg = @cancelled ? @connection.protocol.build_discard(n: -1) : @connection.protocol.build_pull(n: @fetch_size)
-          @connection.send_message(next_msg)
-          @connection.flush
+          if @cancelled
+            @connection.send_message(@connection.protocol.build_discard(n: -1))
+            @connection.flush
+          else
+            promote
+          end
           return
         end
 
@@ -206,9 +250,92 @@ module Neo4j
 
       private
 
+      # First batch reported has_more: hand the remaining batches to a
+      # background pump. Send batch 2's PULL on this (consumer) thread — the
+      # pump issues every PULL after that — then spawn it. Once spawned the
+      # pump is the connection's sole reader/writer; the consumer only ever
+      # touches @buffer, so there's no concurrent socket access. The pump runs
+      # as a fiber under a host scheduler, else its own thread (Executor).
+      def promote
+        @buffer = Bolt::RecordBuffer.new(fetch_size: @fetch_size)
+        source = Bolt::RecordSource.new(@connection)
+        source.pull(@fetch_size)
+        @pump = Bolt::Pump.new(source, @buffer)
+        @pump_handle = Bolt::Executor.spawn { @pump.run }
+        @promoted = true
+      end
+
+      # Next record from the prefetch buffer, or nil at end of stream. A nil
+      # means the pump saw the terminating SUCCESS: finalize from the buffer's
+      # summary, harvest the bookmark, and release the connection — the same
+      # terminal handling on_success does for the synchronous path. The pump's
+      # thread/fiber has finished by then (it closes the buffer last); join it
+      # before release so it can't touch a reused connection. A stream failure
+      # surfaces as a raise from shift (handled by the caller's classifier).
+      def next_buffered_record
+        msg =
+          begin
+            @buffer.shift
+          rescue StandardError
+            @failed = true
+            raise
+          end
+        return build_record(msg) if msg
+
+        # End of stream. A terminating SUCCESS carries summary metadata; a bare
+        # finish (e.g. IGNORED) carries none — mirror Result#on_ignored and just
+        # mark consumed, no summary, like the synchronous path.
+        if (summary = @buffer.summary)
+          finalize(summary)
+          @on_summary&.call(@summary)
+        else
+          @consumed = true
+        end
+        @pump_handle&.join
+        release_connection
+        nil
+      end
+
+      # Materialise every remaining buffered record (used by #buffer).
+      def drain_buffer_into_records
+        while (record = next_buffered_record)
+          @records << record
+        end
+      end
+
+      # Abandon a promoted stream: tell the pump to DISCARD the rest, then drain
+      # the buffer (dropping records, which also unblocks a pump parked in
+      # push_record) until the server's terminating SUCCESS closes it. Harvest
+      # that summary's bookmark — DISCARD still returns one for auto-commit.
+      # A failure surfaced during the drain propagates (classified) exactly as
+      # the synchronous consume() path does; the connection is then left for the
+      # caller to RESET + discard!, not released here.
+      def cancel_via_pump
+        @pump.cancel
+        error = nil
+        begin
+          nil while @buffer.shift
+        rescue StandardError => e
+          @failed = true
+          error = e
+        end
+        @pump_handle&.join
+        raise @connection.classify_failure(error) if error
+
+        if !@consumed && (summary = @buffer.summary)
+          finalize(summary)
+          @on_summary&.call(@summary)
+        else
+          @consumed = true
+        end
+        release_connection
+      end
+
       def drain_until_consumed(&record_handler)
         with_record_handler(record_handler) do
-          @connection.fetch_response.accept(self) until @consumed
+          # Stop on promotion too: once on_success hands the stream to the pump,
+          # the pump is the sole reader — the caller continues from the buffer.
+          @connection.fetch_response.accept(self) until @consumed || @promoted
         end
       end
 

--- a/spec/mri/neo4j/driver/bolt/pump_spec.rb
+++ b/spec/mri/neo4j/driver/bolt/pump_spec.rb
@@ -14,14 +14,18 @@ RSpec.describe Neo4j::Driver::Bolt::Pump do
 
   # A socket-free response source. Emits a scripted first batch; each pull(n)
   # appends the next scripted batch (so has_more → pull → next batch). Records
-  # the pull sizes for assertions.
+  # the pull sizes for assertions. discard(n) appends the `on_discard` batch —
+  # the server's response to DISCARD (a terminating SUCCESS), mirroring how a
+  # real server replies when the cursor abandons the rest.
   class FakeSource
-    attr_reader :pulls
+    attr_reader :pulls, :discards
 
-    def initialize(*batches)
+    def initialize(*batches, on_discard: nil)
       @pending = (batches.shift || []).dup
       @rest = batches
+      @on_discard = on_discard
       @pulls = []
+      @discards = []
     end
 
     def next_response
@@ -33,6 +37,11 @@ RSpec.describe Neo4j::Driver::Bolt::Pump do
     def pull(n)
       @pulls << n
       @pending.concat(@rest.shift || [])
+    end
+
+    def discard(n = -1)
+      @discards << n
+      @pending.concat(@on_discard || [])
     end
   end
 
@@ -72,18 +81,25 @@ RSpec.describe Neo4j::Driver::Bolt::Pump do
     expect { buffer.shift }.to raise_error(Neo4j::Driver::Exceptions::ClientException)
   end
 
-  it 'treats a cancel during backpressure as a clean shutdown, not a stream error' do
-    buffer = RecordBuffer.new(fetch_size: 1, high_watermark: 1, low_watermark: 1)
-    source = FakeSource.new([rec(1), rec(2), done])
+  it 'cancels by DISCARDing the rest and ending on the server terminal' do
+    # low 0 ⇒ the pump parks in await_pull_capacity at the has_more boundary
+    # (size 1 > 0) instead of refilling immediately, giving cancel a window.
+    buffer = RecordBuffer.new(fetch_size: 1, high_watermark: 2, low_watermark: 0)
+    # batch 1 has_more → without cancel the pump would PULL again; on cancel it
+    # DISCARDs and the server replies with the terminating SUCCESS (summary).
+    source = FakeSource.new([rec(1), more], on_discard: [Message::Success.new(bookmark: 'bm')])
     pump = described_class.new(source, buffer)
     handle = Executor.spawn { pump.run }
 
-    sleep 0.05    # pump pushes rec(1) (fills bound 1), then parks pushing rec(2)
-    pump.cancel   # closes the buffer → ClosedQueueError in the parked push
+    sleep 0.05            # pump pushes rec(1), then parks in await_pull_capacity
+    pump.cancel           # flag the buffer; pump will DISCARD at the has_more boundary
 
-    expect(buffer.shift.fields).to eq([1])           # buffered record still delivered
-    expect(Timeout.timeout(2) { buffer.shift }).to be_nil # clean end — NOT a raise
+    expect(buffer.shift.fields).to eq([1])               # buffered record still delivered
+    expect(Timeout.timeout(2) { buffer.shift }).to be_nil # clean end after the DISCARD terminal
     handle.join
+    expect(source.discards).to eq([-1])  # asked the server to abandon the rest
+    expect(source.pulls).to be_empty     # no further PULL once cancelled
+    expect(buffer.summary).to eq(bookmark: 'bm') # terminal summary captured
   end
 
   # Reactor path is CRuby-only (async/fiber-scheduler unsupported on JRuby,

--- a/spec/mri/neo4j/driver/bolt/pump_spec.rb
+++ b/spec/mri/neo4j/driver/bolt/pump_spec.rb
@@ -94,9 +94,9 @@ RSpec.describe Neo4j::Driver::Bolt::Pump do
     sleep 0.05            # pump pushes rec(1), then parks in await_pull_capacity
     pump.cancel           # flag the buffer; pump will DISCARD at the has_more boundary
 
-    expect(buffer.shift.fields).to eq([1])               # buffered record still delivered
+    expect(Timeout.timeout(2) { buffer.shift }.fields).to eq([1]) # buffered record still delivered
     expect(Timeout.timeout(2) { buffer.shift }).to be_nil # clean end after the DISCARD terminal
-    handle.join
+    Timeout.timeout(2) { handle.join }
     expect(source.discards).to eq([-1])  # asked the server to abandon the rest
     expect(source.pulls).to be_empty     # no further PULL once cancelled
     expect(buffer.summary).to eq(bookmark: 'bm') # terminal summary captured

--- a/spec/mri/neo4j/driver/result_prefetch_spec.rb
+++ b/spec/mri/neo4j/driver/result_prefetch_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Neo4j::Driver::Result do
     released = false
     result = result_for([rec(1), rec(2), done(bookmark: 'bm')], on_release: -> { released = true })
 
-    expect(result.to_a.map { _1[:n] }).to eq([1, 2])
+    got = Timeout.timeout(5) { result.to_a.map { _1[:n] } }
+    expect(got).to eq([1, 2])
     expect(result.connection.sent).to be_empty   # no follow-up PULL/DISCARD
     expect(released).to be(true)                  # connection released on terminal
   end

--- a/spec/mri/neo4j/driver/result_prefetch_spec.rb
+++ b/spec/mri/neo4j/driver/result_prefetch_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'timeout'
+
+# Unit coverage for Result's prefetch promotion (MRI-only): the first batch is
+# drained synchronously, and on the first has_more the remaining batches are
+# streamed by a background Bolt::Pump into a RecordBuffer. Single-batch results
+# never promote. Uses a socket-free fake connection that serves a scripted
+# response sequence to both the synchronous batch-1 reader and the pump.
+RSpec.describe Neo4j::Driver::Result do
+  Message = Neo4j::Driver::Bolt::Message
+
+  def rec(*values) = Message::Record.new(values)
+  def more         = Message::Success.new(has_more: true)
+  def done(meta = {}) = Message::Success.new(meta)
+  def fail!(code = 'Neo.ClientError.Statement.SyntaxError') = Message::Failure.new(code: code, message: 'boom')
+
+  # Serves fetch_response from a scripted queue (thread-safe: the synchronous
+  # cursor reads batch 1, then the pump thread reads the rest — never at once,
+  # but a Queue keeps it safe regardless). Records sent PULL/DISCARD messages.
+  let(:connection) do
+    Class.new do
+      attr_reader :sent
+
+      def initialize(script)
+        @queue = Thread::Queue.new
+        script.each { |m| @queue.push(m) }
+        @sent = []
+        @mutex = Mutex.new
+      end
+
+      def fetch_response = @queue.pop
+      def send_message(m) = @mutex.synchronize { @sent << m }
+      def flush = nil
+      def classify_failure(e) = e
+      def protocol = self
+      def build_pull(n:) = [:pull, n]
+      def build_discard(n:) = [:discard, n]
+    end
+  end
+
+  def result_for(script, fetch_size: 2, on_summary: nil, on_release: nil)
+    described_class.new(connection.new(script), %i[n], fetch_size: fetch_size,
+                        on_summary: on_summary, on_release: on_release)
+  end
+
+  it 'does not promote a single-batch result (no extra PULL, no pump)' do
+    released = false
+    result = result_for([rec(1), rec(2), done(bookmark: 'bm')], on_release: -> { released = true })
+
+    expect(result.to_a.map { _1[:n] }).to eq([1, 2])
+    expect(result.connection.sent).to be_empty   # no follow-up PULL/DISCARD
+    expect(released).to be(true)                  # connection released on terminal
+  end
+
+  it 'promotes on the first has_more and streams every remaining batch' do
+    summary = nil
+    # batch1: 1,2 + has_more | batch2: 3,4 + has_more | batch3: 5 + done
+    script = [rec(1), rec(2), more, rec(3), rec(4), more, rec(5), done(type: 'r')]
+    result = result_for(script, on_summary: ->(s) { summary = s })
+
+    got = Timeout.timeout(5) { result.to_a.map { _1[:n] } }
+    expect(got).to eq([1, 2, 3, 4, 5])
+    # one follow-up PULL per extra batch (batch2 sent by promote, batch3 by pump)
+    expect(result.connection.sent).to eq([[:pull, 2], [:pull, 2]])
+    expect(summary).not_to be_nil
+  end
+
+  it 'consume() on a promoted stream DISCARDs the rest and returns the summary' do
+    # fetch_size 4 ⇒ high 8 / low 2, so after promotion the pump parks at
+    # batch-2's has_more boundary (4 buffered, one peeked ⇒ 3 > low) instead of
+    # auto-pulling — giving consume() a deterministic window to cancel. The pump
+    # then DISCARDs and the server replies with the terminating SUCCESS.
+    script = [rec(1), rec(2), more, rec(3), rec(4), rec(5), rec(6), more, done(bookmark: 'bm')]
+    harvested = nil
+    result = result_for(script, fetch_size: 4, on_summary: ->(s) { harvested = s })
+
+    expect(result.next[:n]).to eq(1)   # triggers batch-1 drain
+    expect(result.next[:n]).to eq(2)
+    expect(Timeout.timeout(5) { result.has_next? }).to be(true) # promotes; pump parks at boundary
+
+    Timeout.timeout(5) { result.consume }
+    expect(result.connection.sent).to eq([[:pull, 4], [:discard, -1]])
+    expect(harvested).not_to be_nil
+  end
+
+  it 'surfaces a failure that occurs in a prefetched batch' do
+    # batch1 ok + has_more; batch2 fails mid-stream.
+    script = [rec(1), more, rec(2), fail!]
+    result = result_for(script)
+
+    expect(result.next[:n]).to eq(1)
+    expect do
+      Timeout.timeout(5) { result.to_a }
+    end.to raise_error(Neo4j::Driver::Exceptions::ClientException)
+    expect(result.failed?).to be(true)
+  end
+end


### PR DESCRIPTION
Builds on #396 (merged): wires the dormant `Bolt::Pump` into the live `Result`
streaming path via **lazy promotion**.

## What

- **Single-batch results** keep the zero-overhead synchronous path — their `PULL`
  is already pipelined with `RUN`, so a background pump would add nothing. They
  spawn no worker.
- **On the first `has_more`**, `Result` promotes: it builds a `RecordBuffer` +
  `RecordSource`, sends batch 2's `PULL`, and `Executor.spawn`s a `Bolt::Pump`
  for batches 2..N — a **fiber** under a host Fiber scheduler (Falcon / `Async{}`),
  else a plain **thread**. The pump prefetches batch *k+1* while the consumer
  drains batch *k*.
- **One worker per paginating stream, spanning all pages** (not per page). Once
  promoted the pump is the connection's sole reader/writer; the cursor only
  touches the buffer, so there is no concurrent socket access. The cursor `join`s
  the worker before releasing the connection.
- **`consume()` cancels via the pump**: `DISCARD {n:-1}` at the next batch
  boundary, then reads on to the terminating `SUCCESS` (summary/bookmark
  preserved) so the connection stays reusable. Failures surface from
  `buffer.shift`, classified by the consumer exactly as the synchronous path
  (routing's `SessionExpired` swap, etc.).

Why connection-pinned, per-stream, thread-or-fiber (not a persistent
per-connection worker): a result is server-side stateful and bound to its
connection, so every `PULL` for a stream goes to that one connection. Thread
create/teardown is ~15µs (measured) — noise against the network round-trips a
multi-batch stream already pays — while a persistent parked worker would cost
~52KB resident per pooled connection *and* force a parked fiber-per-connection
under a reactor, which the ambient-reactor model avoids.

## Validation

- New `Result` prefetch unit specs (promotion, prefetch, cancel→DISCARD,
  prefetched-batch failure) + updated pump cancel spec; `spec/mri` green (64).
- Local rust-boltstub: streaming modules (`session_run`, `tx_run`, `iteration`,
  `basic_query`, `summary`, `disconnects`, `optimizations`) and **all** routing
  versions (v3/v4x2/v4x3/v4x4/v5x0) are **byte-identical to `main`** — no
  regression in the affected surface. CI's baseline gate is the authoritative
  cross-flavor check.

Design notes in `docs/sans-io-pump.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming results now intelligently “promote” to background prefetching for multi-batch streams, reducing latency while keeping batch draining responsive.
  * Improved streaming cancellation: when appropriate, remaining results are discarded efficiently to preserve connection reuse and produce consistent outcomes.

* **Bug Fixes**
  * Prevented scheduler-driven execution from being used on JRuby, ensuring consistent fiber/thread behavior across runtimes.

* **Documentation**
  * Expanded streaming architecture docs describing prefetch pump integration and cancellation/discard behavior.

* **Tests**
  * Added/updated specs to verify prefetch promotion and discard-on-cancel messaging and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->