### PR TITLE
refactor(mri): drop redundant ThreadHandle from Executor

### DIFF
--- a/lib/mri/neo4j/driver/bolt/executor.rb
+++ b/lib/mri/neo4j/driver/bolt/executor.rb
@@ -31,24 +31,19 @@ module Neo4j
         def reactor? = RUBY_PLATFORM != 'java' && !Fiber.scheduler.nil?
 
         # Run `block` in the background-appropriate context and return a handle
-        # (responds to #alive?; #join on the thread path). Under a scheduler the
-        # caller and the pump share one thread cooperatively; without one the
-        # pump gets its own thread.
+        # responding to #alive? / #join. Without a scheduler the pump gets its own
+        # thread — a plain Thread already satisfies that interface, so it's
+        # returned as-is. Under a scheduler it's a fiber, wrapped (see below).
         def spawn(&block)
-          reactor? ? FiberHandle.new(Fiber.schedule(&block)) : ThreadHandle.new(Thread.new(&block))
+          reactor? ? FiberHandle.new(Fiber.schedule(&block)) : Thread.new(&block)
         end
 
-        # Thin uniform wrappers so callers don't branch on the handle type.
-        ThreadHandle = Struct.new(:thread) do
-          def alive? = thread.alive?
-          def join = thread.join
-        end
-
+        # Adapter for the reactor path only: a scheduled fiber doesn't satisfy the
+        # thread-shaped handle interface — there's no Fiber#join (it's driven by
+        # the host reactor; the consumer observes completion via the buffer's
+        # stream-end signal, not by joining), and #alive? maps straight through.
         FiberHandle = Struct.new(:fiber) do
           def alive? = fiber.alive?
-          # A scheduled fiber is driven by the host reactor, not joined by a
-          # caller; the consumer observes completion via the buffer's stream-end
-          # signal instead. No-op so the interface stays uniform.
           def join = nil
         end
       end


### PR DESCRIPTION
`Thread` already responds to `#alive?` and `#join` with exactly the semantics the pump handle needs (`@pump_handle&.join`), so `ThreadHandle` was wrapping it for no behavioural gain — only surface symmetry with `FiberHandle`. This returns the bare `Thread` on the thread path.

`FiberHandle` stays, because it genuinely earns its place: a scheduled `Fiber` (from `Fiber.schedule`) has **no `#join`** — it's driven by the host reactor, and completion is observed via the buffer's stream-end signal, not by joining — so `#join` is a deliberate no-op and `#alive?` maps through.

`spawn` now returns either a `Thread` or a `FiberHandle`, both duck-typed to `alive?`/`join`; the call site (`Result#promote` → `@pump_handle&.join`) is unchanged.

Validation: `executor_spec` / `pump_spec` / `result_prefetch_spec` green on CRuby; `executor_spec` / `pump_spec` green on JRuby (mri flavor). The specs only use `spawn` + `handle.join`, which the bare `Thread` satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal concurrency handling in the Neo4j driver by streamlining the thread execution layer and eliminating unnecessary abstraction wrappers, resulting in cleaner, more maintainable code without affecting existing functionality or external behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->