### PR TITLE
feat(mri): incremental record streaming with a shared record/promise wait

### DIFF
--- a/lib/mri/neo4j/driver/bolt/connection.rb
+++ b/lib/mri/neo4j/driver/bolt/connection.rb
@@ -700,8 +700,8 @@ module Neo4j
         # Failure fan-out: a dead/timed-out connection must wake every waiter,
         # not just the front one. Record the classified error, close @inbox so
         # sync poppers (fetch_response) return nil → re-raise it, fail each
-        # outstanding stream buffer (via its handler) so a consumer parked in
-        # buffer.shift re-raises too, and broadcast @quiescent_cv so a drainer
+        # outstanding stream buffer (via its handler) so a cursor parked in
+        # buffer.await wakes and re-raises too, and broadcast @quiescent_cv so a drainer
         # parked in #wait_quiescent (reset!/fetch_all/alive?) wakes on the
         # @broken_error condition instead of waiting forever for an in-flight
         # reply that will never arrive. Idempotent; may run on the reader thread

--- a/lib/mri/neo4j/driver/bolt/record_buffer.rb
+++ b/lib/mri/neo4j/driver/bolt/record_buffer.rb
@@ -5,80 +5,87 @@ module Neo4j
     module Bolt
       # Record buffer for one streaming result, with a high/low watermark autopull
       # policy. Sits between the connection's reader (producer) and the cursor
-      # (consumer). Server→driver flow control *is* the backpressure: the cursor
-      # checks `pull_ready?` as it drains and, when the buffer has fallen to/below
-      # the low watermark and the server has said `has_more`, issues the next
-      # `PULL {n: fetch_size}` (marking it via `note_pull_issued`). Hysteresis
-      # (high ≈ 2× fetch_size, low a fraction) keeps PULLs from thrashing. Because
-      # the cursor only ever requests what it will drain, at most ~one batch sits
-      # unread, so the queue is unbounded — `deliver_batch` never blocks. That
-      # matters: the reader dispatches under the wire lock, so a blocking enqueue
-      # could stall every request on the connection (docs/unified-pipeline.md).
+      # (consumer), and unifies two things under one mutex + condition variable:
+      # the record queue *and* the batch's "has_more promise".
       #
-      # All sync primitives are stdlib + scheduler-aware, so a consumer running as
-      # a fiber under a host reactor yields rather than blocking the thread.
+      # Records are delivered incrementally — pushed the instant the reader decodes
+      # them — so the cursor sees record 1 without waiting for the whole batch. The
+      # batch's terminating SUCCESS resolves the promise (`batch_complete`), which
+      # says whether the server has more. The cursor drives flow control:
+      #
+      #   * after each record, once drained to/below the low watermark, it checks
+      #     the promise (`pull_ready?`, non-blocking) and, if fulfilled with
+      #     has_more, issues the next `PULL {n: fetch_size}` — prefetch overlap;
+      #   * when it drains the buffer empty mid-stream, it `await`s — one wait that
+      #     wakes on *either* the next record *or* the promise resolving. That
+      #     shared wait is the crux: mid-batch it wakes on a record (incremental
+      #     delivery preserved), at batch-end it wakes on the promise (so it PULLs
+      #     the next batch instead of blocking forever on a record that, the SUCCESS
+      #     having no payload, will never come).
+      #
+      # The cursor is the sole writer (issues every PULL/DISCARD); the reader only
+      # ever fills. All sync primitives are stdlib + scheduler-aware, so a cursor
+      # running as a fiber under a host reactor yields rather than blocking the
+      # thread. See docs/unified-pipeline.md.
       class RecordBuffer
         attr_reader :fetch_size, :high_watermark, :low_watermark
 
         def initialize(fetch_size:, high_watermark: nil, low_watermark: nil)
           @fetch_size = fetch_size
-          # Defaults: hold ~2 batches, refill under half a batch. fetch_size -1
-          # ("pull all in one batch") never paginates, so just size the bound for
-          # a steady single-batch handoff.
+          # Defaults: refill under half of ~2 batches held. fetch_size -1 ("pull
+          # all in one batch") never paginates, so just size the watermarks for a
+          # steady single-batch handoff.
           @high_watermark = high_watermark || (fetch_size.positive? ? fetch_size * 2 : 1000)
           @low_watermark = low_watermark || [@high_watermark / 2, 1].max
-          # Unbounded: the watermark gates how much the cursor pulls, so this never
-          # grows past ~one batch of unread records. deliver_batch must not block —
-          # the reader enqueues while holding the wire lock.
-          @queue = Thread::Queue.new
           @mutex = Mutex.new
+          @cv = ConditionVariable.new
+          @records = []           # incrementally filled by the reader, drained by the cursor
           @has_more = true        # server may have more records for this stream
-          @pull_in_flight = true  # the first PULL is pipelined with RUN by the cursor
-          @ended = false          # final SUCCESS/IGNORED seen → no more records
-          @error = nil            # stream failed; re-raised to the consumer
+          @pull_in_flight = true  # the first PULL is pipelined with RUN — promise unfulfilled
+          @ended = false          # terminal SUCCESS/IGNORED seen → no more records
+          @error = nil            # stream failed; re-raised to the cursor after buffered records
           @summary = nil          # terminating SUCCESS metadata
         end
 
         # --- Producer (reader) side -----------------------------------------
 
-        # Deliver a whole batch atomically: enqueue its records *and* clear the
-        # pull-in-flight flag (recording whether the server has more) in one
-        # synchronized step. The atomicity is the crux — a consumer that pops any
-        # of these records and then checks the autopull policy is guaranteed to
-        # see the matching has_more/pull-in-flight state, so it issues the next
-        # PULL at the right time instead of parking on a stale "in flight" flag.
-        # Never blocks (unbounded queue); the cursor's watermark bounds how much
-        # the server ships.
-        def deliver_batch(records, has_more:)
-          @mutex.synchronize do
-            records.each { |record| @queue.push(record) }
-            @has_more = has_more
-            @pull_in_flight = false
-          end
+        # Append a decoded record and wake a cursor parked in #await. Never blocks
+        # (unbounded); the cursor's watermark bounds how much the server ships.
+        def push_record(record)
+          @mutex.synchronize { @records.push(record); @cv.broadcast }
         end
 
-        # Final batch: deliver its records, stash the terminating SUCCESS metadata,
-        # and close the queue so a consumer parked in shift wakes with nil.
-        def finish(records = [], summary = nil)
+        # The current batch's terminal SUCCESS arrived — resolve the promise.
+        # `has_more` says whether to keep paging; either way no PULL is in flight,
+        # so the cursor may issue the next once it drains past the low watermark.
+        # Wake a cursor parked in #await waiting for exactly this.
+        def batch_complete(has_more:)
+          @mutex.synchronize { @has_more = has_more; @pull_in_flight = false; @cv.broadcast }
+        end
+
+        # Final batch (terminating SUCCESS without has_more, or IGNORED): stash the
+        # summary, mark ended, and wake the cursor.
+        def finish(summary = nil)
           @mutex.synchronize do
-            records.each { |record| @queue.push(record) }
             @summary = summary
             @ended = true
             @has_more = false
+            @pull_in_flight = false
+            @cv.broadcast
           end
-          @queue.close
         end
 
-        # The stream failed: deliver any records that preceded the failure in this
-        # batch, then arm the error the consumer re-raises once the queue drains.
-        def fail(error, records = [])
+        # The stream failed: arm the error the cursor re-raises *after* it drains
+        # the records already delivered (records that preceded the failure are
+        # valid), and wake it.
+        def fail(error)
           @mutex.synchronize do
-            records.each { |record| @queue.push(record) }
             @error ||= error
             @ended = true
             @has_more = false
+            @pull_in_flight = false
+            @cv.broadcast
           end
-          @queue.close
         end
 
         # The terminating SUCCESS's metadata (nil until finished / on failure).
@@ -86,28 +93,42 @@ module Neo4j
 
         # --- Consumer (cursor) side -----------------------------------------
 
-        # Next record, or nil when the stream is exhausted. Blocks (yields under a
-        # scheduler) until a record arrives or the stream ends. Re-raises a
-        # stream failure.
-        def shift
-          record = @queue.pop # nil once closed and drained
-          raise @error if record.nil? && @error
+        # Non-blocking: the next buffered record, or :empty when none is buffered
+        # yet, or :ended once the stream is drained and terminal. Buffered records
+        # are handed out before a stream failure is raised (they preceded it).
+        def try_shift
+          @mutex.synchronize do
+            return @records.shift unless @records.empty?
+            raise @error if @error
 
-          record
+            @ended ? :ended : :empty
+          end
         end
 
-        def empty? = @queue.empty?
-        def size = @queue.size
+        # Block (colorlessly) until there's something to re-evaluate: a record was
+        # delivered, the batch completed (promise resolved), or the stream
+        # ended/failed. Called only when the cursor has drained the buffer empty
+        # and a PULL is still outstanding (records coming, or its SUCCESS pending).
+        def await
+          @mutex.synchronize do
+            @cv.wait(@mutex) while @records.empty? && !@ended && @error.nil? && @pull_in_flight
+          end
+        end
+
+        def empty? = @mutex.synchronize { @records.empty? }
+        def size = @mutex.synchronize { @records.size }
         def ended? = @mutex.synchronize { @ended }
         def has_more? = @mutex.synchronize { @has_more }
 
         # --- Autopull policy (cursor side) ----------------------------------
 
-        # True when the cursor should issue the next PULL: the server has more,
-        # none is in flight, and the buffer has drained to/below the low watermark.
-        def pull_ready? = @mutex.synchronize { @has_more && !@pull_in_flight && @queue.size <= @low_watermark }
+        # True when the cursor should issue the next PULL: the batch promise is
+        # fulfilled (none in flight) with has_more, and the buffer has drained
+        # to/below the low watermark.
+        def pull_ready? = @mutex.synchronize { @has_more && !@pull_in_flight && @records.size <= @low_watermark }
 
-        # The cursor issued the next PULL; don't issue another until it completes.
+        # The cursor issued the next PULL — the promise is unfulfilled again; don't
+        # issue another until this batch completes.
         def note_pull_issued = @mutex.synchronize { @pull_in_flight = true }
       end
     end

--- a/lib/mri/neo4j/driver/bolt/stream_handler.rb
+++ b/lib/mri/neo4j/driver/bolt/stream_handler.rb
@@ -6,65 +6,46 @@ module Neo4j
       # The wire handler for a streaming PULL/DISCARD: the dedicated reader routes
       # the result's replies here, and it fills the result's RecordBuffer.
       #
-      # It accumulates a whole batch's records and hands them to the buffer
-      # *together with* the batch's has_more flag, in one atomic delivery, only
-      # once the batch's terminal reply (SUCCESS/FAILURE/IGNORED) arrives. That
-      # atomicity is what makes the cursor's consumer-driven autopull correct
-      # under true parallelism (JRuby): a consumer can never observe a record
-      # without also observing the has_more/pull-in-flight state that goes with
-      # it, so its post-shift watermark check always issues the next PULL at the
-      # right moment. (Pushing records as they arrived, then flipping the flag on
-      # the later SUCCESS, let the consumer drain and park before the flag flipped
-      # — a lost-pull deadlock. See docs/unified-pipeline.md.)
+      # Records are forwarded to the buffer incrementally — the instant each is
+      # decoded — so the cursor can read record 1 without waiting for the whole
+      # batch. The batch's terminating SUCCESS resolves the buffer's has_more
+      # promise (batch_complete) or ends the stream (finish); a FAILURE/IGNORED
+      # ends it too. The cursor consumes the buffer and drives follow-up PULLs —
+      # this side only fills.
       #
-      # Runs in the reader thread; @batch is reader-local (no other thread touches
-      # it). Same visitor interface as @collector, so the wire dispatches to it
-      # identically.
+      # Runs in the reader thread; same visitor interface as @collector, so the
+      # wire dispatches to it identically.
       class StreamHandler
         def initialize(buffer)
           @buffer = buffer
-          @batch = []
         end
 
         def on_record(message)
-          @batch << message
+          @buffer.push_record(message)
         end
 
         def on_success(message)
-          batch = take_batch
           if message.metadata[:has_more]
-            @buffer.deliver_batch(batch, has_more: true)
+            @buffer.batch_complete(has_more: true)
           else
-            @buffer.finish(batch, message.metadata)
+            @buffer.finish(message.metadata)
           end
         end
 
         def on_failure(message)
-          # Deliver any records that preceded the failure in this batch (e.g.
-          # UNWIND [1,0,2]/x yields record(10) then FAILURE), then the error.
-          @buffer.fail(message.to_exception, take_batch)
+          # Records already delivered stay readable; the cursor hits this error
+          # once it drains them (records that preceded the failure are valid).
+          @buffer.fail(message.to_exception)
         end
 
         def on_ignored(_message)
-          @buffer.finish(take_batch)
+          @buffer.finish
         end
 
         # Connection failure fan-out (see Connection#fan_out / Wire#fail_pending):
-        # surface the error to a consumer parked in buffer.shift. Records that
-        # arrived before the break are valid Bolt replies, so deliver them first
-        # (the consumer reads them, then hits the error) — e.g. a PULL that
-        # streamed a RECORD then the connection dropped before the SUCCESS must
-        # still yield that record, then fail on the next read.
+        # surface the error to a cursor parked in the buffer.
         def fail(error)
-          @buffer.fail(error, take_batch)
-        end
-
-        private
-
-        def take_batch
-          batch = @batch
-          @batch = []
-          batch
+          @buffer.fail(error)
         end
       end
     end

--- a/lib/mri/neo4j/driver/result.rb
+++ b/lib/mri/neo4j/driver/result.rb
@@ -152,31 +152,41 @@ module Neo4j
       private
 
       # Next record from the buffer (reader-filled), or nil at end of stream.
-      # Drives the next PULL once the buffer drains past the low watermark. At end,
-      # finalizes from the terminal summary and releases. A stream FAILURE surfaces
-      # as a raise from shift — classified (routing's ServiceUnavailable→
-      # SessionExpired etc.) and marked @failed so the caller RESETs.
+      # Records arrive incrementally, so take one the moment it's buffered and
+      # prefetch (request_more) once we drain past the low watermark. When the
+      # buffer is momentarily empty but the stream is still open, issue any due
+      # PULL then #await — a single wait that wakes on the next record (mid-batch)
+      # or the batch promise resolving (batch-end, so we PULL the next batch
+      # rather than block forever). A stream FAILURE surfaces as a raise from
+      # try_shift — classified (routing's ServiceUnavailable→SessionExpired etc.)
+      # and marked @failed so the caller RESETs.
       def next_record
-        record =
-          begin
-            @buffer.shift
-          rescue StandardError => e
-            @failed = true
-            @consumed = true
-            # A FAILURE carries no summary counters, but the run metadata still
-            # yields a meaningful summary (query text, zero counters) — build it
-            # so a subsequent #consume returns it after re-raising the failure
-            # once (matches main's on_failure, which finalized on the failure).
-            finalize({})
-            raise @connection.classify_failure(e)
+        loop do
+          record = take_from_buffer
+          case record
+          when :empty
+            request_more
+            @buffer.await
+          when :ended
+            finalize_stream
+            return nil
+          else
+            request_more
+            return build_record(record)
           end
-        if record.nil?
-          finalize_stream
-          return nil
         end
+      end
 
-        request_more
-        build_record(record)
+      # try_shift, but turn a stream failure into the classified exception and
+      # finalize a summary from run metadata so a later #consume still returns it
+      # (matches main's on_failure, which finalized on the failure).
+      def take_from_buffer
+        @buffer.try_shift
+      rescue StandardError => e
+        @failed = true
+        @consumed = true
+        finalize({})
+        raise @connection.classify_failure(e)
       end
 
       # Watermark autopull: once the buffer has drained to/below the low watermark

--- a/spec/mri/neo4j/driver/bolt/record_buffer_spec.rb
+++ b/spec/mri/neo4j/driver/bolt/record_buffer_spec.rb
@@ -5,37 +5,46 @@ require 'timeout'
 RSpec.describe Neo4j::Driver::Bolt::RecordBuffer do
   subject(:buffer) { described_class.new(fetch_size: 4, high_watermark: 4, low_watermark: 2) }
 
-  describe 'producer/consumer handoff' do
-    it 'shifts records in order then nil at end of stream' do
-      buffer.deliver_batch([:a, :b], has_more: true)
+  describe 'incremental producer/consumer handoff' do
+    it 'hands out records in order, :empty when momentarily drained, :ended at close' do
+      buffer.push_record(:a)
+      buffer.push_record(:b)
+      expect(buffer.try_shift).to eq(:a)
+      expect(buffer.try_shift).to eq(:b)
+      expect(buffer.try_shift).to eq(:empty) # drained but stream still open
       buffer.finish
-      expect(buffer.shift).to eq(:a)
-      expect(buffer.shift).to eq(:b)
-      expect(buffer.shift).to be_nil # exhausted
+      expect(buffer.try_shift).to eq(:ended)
     end
 
-    it 're-raises a stream failure to the consumer, after any records that preceded it' do
+    it 'delivers records before raising a stream failure' do
       err = Neo4j::Driver::Exceptions::ServiceUnavailableException.new('boom')
-      buffer.fail(err, [:a])
-      expect(buffer.shift).to eq(:a)             # record that preceded the failure
-      expect { buffer.shift }.to raise_error(err) # then the failure
-    end
-
-    it 'blocks the consumer on an empty buffer until a batch arrives' do
-      buffer # instantiate
-      producer = Thread.new { sleep 0.05; buffer.deliver_batch([:late], has_more: true) }
-      got = Timeout.timeout(2) { buffer.shift }
-      expect(got).to eq(:late)
-      producer.join
+      buffer.push_record(:a)
+      buffer.fail(err)
+      expect(buffer.try_shift).to eq(:a)            # record that preceded the failure
+      expect { buffer.try_shift }.to raise_error(err) # then the failure
     end
   end
 
-  describe 'unbounded queue (backpressure is the cursor watermark, not a bound)' do
-    it 'never blocks delivery — the reader dispatches under the wire lock' do
-      blocked = Thread.new { 100.times { |i| buffer.deliver_batch([i], has_more: true) } }
-      Timeout.timeout(2) { blocked.join }
-      expect(blocked).not_to be_alive
-      expect(buffer.size).to eq(100)
+  describe '#await — one wait woken by a record OR the batch promise' do
+    it 'wakes when a record is delivered mid-stream' do
+      producer = Thread.new { sleep 0.05; buffer.push_record(:late) }
+      Timeout.timeout(2) { buffer.await }
+      expect(buffer.try_shift).to eq(:late)
+      producer.join
+    end
+
+    it 'wakes when the batch completes (promise resolves) with no new record' do
+      # First PULL is in flight (@pull_in_flight true); a bare batch_complete
+      # must release a cursor that has drained the buffer empty.
+      producer = Thread.new { sleep 0.05; buffer.batch_complete(has_more: true) }
+      Timeout.timeout(2) { buffer.await }
+      expect(buffer.pull_ready?).to be(true) # cursor can now PULL the next batch
+      producer.join
+    end
+
+    it 'returns immediately once the stream has ended' do
+      buffer.finish
+      Timeout.timeout(2) { buffer.await }
     end
   end
 
@@ -45,28 +54,28 @@ RSpec.describe Neo4j::Driver::Bolt::RecordBuffer do
     end
 
     it 'does not pull while the buffer is above the low watermark' do
-      buffer.deliver_batch([1, 2, 3], has_more: true) # size 3 > low (2), in flight cleared
+      3.times { |i| buffer.push_record(i) } # size 3 > low (2)
+      buffer.batch_complete(has_more: true) # promise fulfilled
       expect(buffer.pull_ready?).to be(false)
     end
 
-    it 'is pull-ready once a delivered batch sits at/below the low watermark' do
-      buffer.deliver_batch([1, 2], has_more: true) # size 2 == low, in flight cleared
+    it 'is pull-ready once the batch completes and the buffer is at/below the low watermark' do
+      2.times { |i| buffer.push_record(i) } # size 2 == low
+      buffer.batch_complete(has_more: true)
       expect(buffer.pull_ready?).to be(true)
     end
 
-    it 'withholds another pull once one is noted in flight, until the next batch is delivered' do
-      buffer.deliver_batch([1, 2], has_more: true)
+    it 'withholds another pull once one is noted in flight, until the next batch completes' do
+      buffer.batch_complete(has_more: true)
       expect(buffer.pull_ready?).to be(true)
       buffer.note_pull_issued
-      expect(buffer.pull_ready?).to be(false)            # in flight
-      buffer.shift
-      buffer.shift                                       # drain the batch (size 0)
-      buffer.deliver_batch([3, 4], has_more: true)       # next batch → not in flight, size 2 == low
+      expect(buffer.pull_ready?).to be(false)  # promise unfulfilled again
+      buffer.batch_complete(has_more: true)    # next batch's SUCCESS
       expect(buffer.pull_ready?).to be(true)
     end
 
     it 'withholds further pulls after the server says no has_more' do
-      buffer.deliver_batch([1, 2], has_more: false)
+      buffer.batch_complete(has_more: false)
       expect(buffer.pull_ready?).to be(false)
     end
   end

--- a/spec/mri/neo4j/driver/bolt/record_buffer_spec.rb
+++ b/spec/mri/neo4j/driver/bolt/record_buffer_spec.rb
@@ -74,8 +74,10 @@ RSpec.describe Neo4j::Driver::Bolt::RecordBuffer do
       expect(buffer.pull_ready?).to be(true)
     end
 
-    it 'withholds further pulls after the server says no has_more' do
-      buffer.batch_complete(has_more: false)
+    it 'withholds further pulls once the stream finishes (the no-has_more path)' do
+      # A terminal SUCCESS without has_more goes through #finish, not
+      # batch_complete — StreamHandler only ever calls batch_complete(has_more: true).
+      buffer.finish
       expect(buffer.pull_ready?).to be(false)
     end
   end


### PR DESCRIPTION
## Summary

Follow-up to #404 (dedicated per-connection reader). That PR landed **atomic whole-batch delivery** to close a lost-PULL deadlock — correct, but it held every record until the batch's terminating SUCCESS, so first-record latency ≈ whole-batch receive time. This restores **incremental delivery** (records visible as they arrive) without reopening the deadlock.

## Design

`RecordBuffer` unifies the record queue and the batch's `has_more` **promise** under **one `Mutex` + `ConditionVariable`**:

- **Reader** pushes each record the instant it decodes it (`push_record`) and resolves the promise on the batch's terminal (`batch_complete` / `finish` / `fail`), signalling the shared cv each time.
- **Cursor** takes records as they land (`try_shift`, non-blocking) and, once drained to/below the low watermark with the promise fulfilled + `has_more`, issues the next `PULL` — **prefetch overlap** preserved.
- When the cursor drains the buffer empty mid-stream it **`await`s** — one wait woken by *either* the next record (mid-batch → incremental delivery) *or* the promise resolving (batch-end → PULL the next batch instead of blocking forever on a payload-less SUCCESS). **That shared wait is the crux** — it's what the atomic-batch delivery avoided by never letting records and the has_more flag be observed separately.

The cursor stays the **sole writer** (issues every PULL/DISCARD); the reader only ever fills. `StreamHandler` drops its batch accumulation and forwards records/terminals straight through. All of #404's break-path/concurrency fixes (wire `@handlers` mutex, `fan_out`/`stop_reader`/`flush`, `@collector` rebind) are untouched.

## Validation

- Buffer-logic unit checks — CRuby **and** JRuby (incl. the deadlock case: `await` woken by a bare `batch_complete`)
- Nested + partial-iteration stress loop **100× on CRuby and JRuby** (`NEO4J_DRIVER_FORCE_MRI=1`) — the exact concurrency surface that regressed during #404
- `spec/shared` + `spec/mri` **530/0/1** on CRuby and JRuby (Neo4j 5 enterprise)
- rust-boltstub `iteration` / `disconnects` modules match baseline, **zero timeouts**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamed records are now delivered incrementally, so results can become available sooner while a query is still running.
  * Result consumption now handles waiting, completion, and end-of-stream states more smoothly.

* **Bug Fixes**
  * Improved handling of stream failures so already-received records and final summaries are preserved more reliably.
  * Fixed record buffering and pull behavior to better respect stream completion and backpressure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->