### PR TITLE
fix(mri): discard connection when pool-return RESET fails (test_fail_on_reset)

### DIFF
--- a/.github/testkit-stub-baseline-mri.txt
+++ b/.github/testkit-stub-baseline-mri.txt
@@ -118,6 +118,7 @@ Stub tests::test_execute_write_retry (tests.stub.driver_parameters.telemetry.tes
 Stub tests::test_execute_write_retry (tests.stub.driver_parameters.telemetry.test_telemetry.TestTelemetryRouting.test_execute_write_retry)
 Stub tests::test_expiring_token_deadline (tests.stub.authorization.test_bearer_auth_manager.TestBearerAuthManager5x0.test_expiring_token_deadline)
 Stub tests::test_expiring_token_deadline (tests.stub.authorization.test_bearer_auth_manager.TestBearerAuthManager5x1.test_expiring_token_deadline)
+Stub tests::test_fail_on_reset (tests.stub.disconnects.test_disconnects.TestDisconnects.test_fail_on_reset)
 Stub tests::test_failed_tx_run_allows_rollback (tests.stub.tx_run.test_tx_run.TestTxRun.test_failed_tx_run_allows_rollback)
 Stub tests::test_failed_tx_run_allows_skipping_rollback (tests.stub.tx_run.test_tx_run.TestTxRun.test_failed_tx_run_allows_skipping_rollback)
 Stub tests::test_fill_diagnostic_record_values (tests.stub.summary.test_summary.TestSummaryGqlStatusObjects5x6.test_fill_diagnostic_record_values)

--- a/lib/mri/neo4j/driver/bolt/connection.rb
+++ b/lib/mri/neo4j/driver/bolt/connection.rb
@@ -571,7 +571,11 @@ module Neo4j
         def reset!(propagate: false)
           send_message(Message.reset)
           flush
-          drain_quiesced
+          messages = drain_quiesced
+          # When propagating (verify_connectivity, pool-return) the RESET is a
+          # real check: a server FAILURE reply (not just a dead socket) must
+          # surface too, so assert success on the drained responses.
+          messages.each(&:assert_success!) if propagate
         rescue StandardError
           # If RESET itself fails the connection is likely dead. Recovery paths
           # (`propagate: false`, the default) swallow so they don't mask the

--- a/lib/mri/neo4j/driver/bolt/pool.rb
+++ b/lib/mri/neo4j/driver/bolt/pool.rb
@@ -104,7 +104,15 @@ module Neo4j
           # It also keeps the liveness probe distinct from the return-RESET, so a
           # silently-dead connection is actually detected on re-acquire
           # (test_should_drop_connections_failing_liveness_check).
-          connection.reset!
+          #
+          # If that RESET fails the connection is dead — discard it (closing the
+          # socket) rather than pooling a broken connection (test_fail_on_reset).
+          begin
+            connection.reset!(propagate: true)
+          rescue StandardError
+            discard(connection)
+            return
+          end
           connection.idle_since = current_monotonic
           @stack.push(connection)
           bump(leased: -1) # returned to the pool, now idle


### PR DESCRIPTION
## Robustness follow-up to #412's reset-on-return

#412 made `Bolt::Pool#push` RESET a connection on return, but `reset!` swallowed the outcome — so a connection whose RESET **failed** (server FAILURE or dead socket) was pooled as if healthy.

- `reset!(propagate: true)` now asserts success on the drained RESET response, so a server `FAILURE` reply surfaces (previously only a dead socket did).
- `push` **discards** the connection (closing the socket) when the return-RESET fails, instead of pooling a broken one.

## Result

Greens `test_fail_on_reset` (`Feature:Bolt:4.4`): the failing RESET on `session.close` now hangs up the connection (accept 1 / hangup 1 / active 0).

Verified on the **rust boltstub** (= CI): disconnects (12/0), verify_connectivity (24/0), drop_connections, v5x0 routing, tx_run, iteration — no new regressions. MRI unit specs 66/0.

### Note on the rest of Feature:Bolt:4.4
The other Bolt:4.4 failures are `test_full_notification` ×2. I attempted a fix but backed it out: the testkit notification **shape contract is inconsistent across Bolt versions** (4.4 without NotificationsConfig wants a minimal notification; the 5.x classes want the full severity/category fields on MRI too), so a uniform backend rule fixed the 4.4 pair but broke 4 of the 5.x notification tests. That needs a dedicated, per-version analysis — out of scope for this robustness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)