### PR TITLE
fix(ci): count testkit failures when stderr splits unittest's summary line

### DIFF
--- a/.github/actions/testkit-postprocess/action.yml
+++ b/.github/actions/testkit-postprocess/action.yml
@@ -178,14 +178,25 @@ runs:
         #     OK | OK (skipped=S) | FAILED (failures=F, errors=E, skipped=S)
         # Pass = Ran - failures - errors - skipped, matching unittest's
         # own arithmetic.
+        #
+        # Accumulate each token wherever it appears rather than gating on a
+        # line that STARTS with OK/FAILED: an interleaved stderr warning
+        # (nutkit prints UserWarnings with no trailing newline) can glue
+        # onto "FAILED" and shove its "(failures=.., errors=.., skipped=..)"
+        # tail onto a separate later line. The old /^(OK|FAILED)/ guard then
+        # matched a bare "FAILED<warning>" with no numbers and counted zero
+        # failures — so a run with real failures rendered as all-green (seen
+        # on the mri stub job while mri-on-jruby, whose output interleaved
+        # differently, read correctly). failures= / errors= / skipped= only
+        # ever occur in unittest's summary group(s), so matching anywhere is
+        # safe; `Ran [0-9]+ tests` likewise (substr+coerce tolerates a glued
+        # prefix that would break `$2`).
         read -r PASS FAIL ERROR SKIP < <(awk '
-          /^Ran [0-9]+ tests?/ { ran += $2 }
           # No \b — POSIX awk (the CI runner default) does not support it.
-          /^(OK|FAILED)/ {
-            if (match($0, /failures=[0-9]+/)) fail += substr($0, RSTART+9, RLENGTH-9)
-            if (match($0, /errors=[0-9]+/))   err  += substr($0, RSTART+7, RLENGTH-7)
-            if (match($0, /skipped=[0-9]+/))  skip += substr($0, RSTART+8, RLENGTH-8)
-          }
+          match($0, /Ran [0-9]+ tests?/) { ran += substr($0, RSTART + 4) + 0 }
+          match($0, /failures=[0-9]+/)   { fail += substr($0, RSTART + 9, RLENGTH - 9) }
+          match($0, /errors=[0-9]+/)     { err  += substr($0, RSTART + 7, RLENGTH - 7) }
+          match($0, /skipped=[0-9]+/)    { skip += substr($0, RSTART + 8, RLENGTH - 8) }
           END { printf "%d %d %d %d\n", ran-fail-err-skip, fail, err, skip }
         ' "$LOG")
         {


### PR DESCRIPTION
## Problem
The testkit **stub** job's Pass/Fail/Error/Skip table showed the **mri** flavor passing *everything* (Fail 0 / Error 0), while **mri-on-jruby** — the same MRI code under JRuby — reported realistic failures. That asymmetry was the tell: it's a parsing bug, not a driver difference.

## Root cause
The `testkit-postprocess` "Summarise counts" step read `failures=`/`errors=`/`skipped=` only from a line **starting** with `OK`/`FAILED`. nutkit prints `UserWarning`s to stderr with no trailing newline, which can glue onto `FAILED` and push its `(failures=F, errors=E, skipped=S)` tail onto a **separate later line**:

```
Ran 1607 tests in 688.038s
FAILED/testkit/nutkit/protocol/responses.py:496: UserWarning: Backend supports address field...
  warnings.warn(...)
 (failures=2, errors=4, skipped=319)      <- 8 lines below the FAILED token
```

The `/^(OK|FAILED)/` guard matched the mangled `FAILED<warning>` line, found no numbers, and counted zero. mri-on-jruby's output interleaved differently (tail stayed intact), so it read correctly.

## Fix
Accumulate `Ran` / `failures=` / `errors=` / `skipped=` **wherever they appear** instead of gating on line-start. Those tokens only occur in unittest's end-of-run summary group(s) (summed across the integration suite's per-config runs), so matching anywhere is safe and robust to the split.

Verified on both captured run logs — each now reports **Pass 1282 / Fail 2 / Error 4 / Skip 319** (mri was **1607 / 0 / 0 / 0**).

## Scope
Reporting only. The **regression gate is unaffected** — it already compares the inline-token fail set and the pass list against the baseline (both green here); this only fixes the human-facing count table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test result summaries to accurately capture failure, error, and skipped-test counts even when warnings or other output interrupt the standard summary format.
  * Preserved accurate pass-count calculations based on the total number of tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->