### PR TITLE
fix(mri): re-consult auth manager on Bolt 5.0 routed re-auth [Feature:Auth:Managed]

### DIFF
--- a/lib/mri/neo4j/driver/routing/load_balancer.rb
+++ b/lib/mri/neo4j/driver/routing/load_balancer.rb
@@ -70,13 +70,16 @@ module Neo4j
 
           access_mode = access_mode.to_sym
           # `auth` is the per-session override (nil = manager's current
-          # token). Resolve the worker identity once — this is the worker's
-          # single manager consult. Discovery resolves its own identity
-          # independently (below), so a routed acquire with the default token
-          # consults the manager twice (get_auth_count == 2): once for the
-          # ROUTE connection, once for the worker. A session-carried token
-          # short-circuits both (count 0).
-          effective = auth || @auth_manager.get_token
+          # token). The worker identity is resolved per turn inside the loop
+          # below, not once here: on Bolt 5.0 an acquire that discards a
+          # token-rotated connection must re-consult the manager so the
+          # replacement issues its own get_token (mirrors
+          # Direct::ConnectionProvider — one extra get_auth per rotation).
+          # Discovery resolves its own identity independently, so a routed
+          # acquire with the default token consults the manager twice
+          # (get_auth_count == 2): once for the ROUTE connection, once for the
+          # worker. A session-carried token short-circuits both (count 0).
+          #
           # imp_user is threaded into discovery so the ROUTE call enforces
           # impersonation support (Bolt 4.4+) against the router, matching
           # the RUN/BEGIN path — see Connection#route. `auth` is threaded so
@@ -109,6 +112,9 @@ module Neo4j
             pool = pool_for(address)
             begin
               epoch = auth_epoch_for(address)
+              # Re-resolve per turn (see acquire header): a discard-and-retry
+              # on Bolt 5.0 token rotation must issue its own get_token.
+              effective = auth || @auth_manager.get_token
               inner = pool.pop(auth: effective)
               begin
                 ensure_identity(inner, effective, session_auth: auth, address: address, epoch: epoch)
@@ -404,14 +410,15 @@ module Neo4j
           pool = pool_for(router)
           conn = nil
           begin
-            # Resolve discovery's identity once — its single, independent
-            # manager consult (per-session token short-circuits it). Used for
+            # Discovery's identity is resolved per turn inside the loop below
+            # (per-session token short-circuits the manager consult). It sets
             # BOTH the fresh-connection token and the re-auth of a reused
             # router connection: pool.pop(auth:) only sets a *fresh*
             # connection's identity, so without ensure_identity a reused
             # ROUTE connection would run under the previous lessee's user
-            # (and skip the Bolt 5.1 gate for per-session auth).
-            effective = auth || @auth_manager.get_token
+            # (and skip the Bolt 5.1 gate for per-session auth). Re-resolving
+            # each turn means a Bolt 5.0 discard-and-rebuild on token rotation
+            # issues its own get_token, matching the worker path in #acquire.
             # pop is inside the begin block on purpose: open_connection
             # is the pool's create block and can raise ServiceUnavailable
             # (router unreachable). If that escaped the method,
@@ -424,6 +431,7 @@ module Neo4j
             # and rebuilt rather than ROUTEing under a stale identity.
             loop do
               epoch = auth_epoch_for(router)
+              effective = auth || @auth_manager.get_token
               conn = pool.pop(auth: effective)
               ensure_identity(conn, effective, session_auth: auth, address: router, epoch: epoch)
               break if conn.protocol.supports_re_auth? ||


### PR DESCRIPTION
Fixes the last of the 6 stub failures: `TestAuthTokenManager5x0.test_dynamic_auth_manager` (routing subtest) — `get_auth_count` was **8, expected 10**.

## Root cause
Both routing acquire paths resolved the managed-auth token **once, before** their per-address loop:
- `LoadBalancer#acquire` — the worker connection
- `LoadBalancer#fetch_routing_table_from` — the ROUTE/discovery connection

On **Bolt 5.0** there's no in-place `LOGOFF`/`LOGON`, so when the auth manager rotates its token, a pooled connection with the old identity is discarded and the loop retries — but with `effective` already fetched, the replacement reused the **stale** token and issued **no** fresh `get_token`. The managed-auth contract expects one extra `getAuth` per rotation for the backwards-compatible (connection-replacing) path. Expected `10 = (4 base + 1 rotation) × 2` (router + worker); MRI produced `8`.

`Direct::ConnectionProvider#acquire` already re-resolves the token each turn for exactly this reason (and the non-routing subtest passed). This moves both routing paths to the same per-turn resolution.

On Bolt 5.1+ the discard branch never fires (in-place re-auth), so the loop runs once and counts are unchanged — confirmed by the full suite.

## Note on why CI didn't flag it
The test was **already in the stub baseline** but failing **silently**: the gate's fail-set parser keys on inline ` ... FAIL` tokens, which `unittest` `subTest` failures don't emit (they surface only in the end-of-run `FAIL:` block). So a red subtest passed the gate as green. This PR makes the baselined test honestly pass; hardening the gate against subtest blindness is a separate follow-up.

## Validation (rust boltstub, local MRI backend)
- `TestAuthTokenManager5x0.test_dynamic_auth_manager` ✅ (both routing subtests)
- Full authorization suite green: `test_auth_token_manager` 16, `test_authorization` 113 (2 skip), basic/bearer/user_switching 28
- MRI unit specs 66/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)