### PR TITLE
feat(mri): session-level NotificationsConfig on BEGIN/RUN [Feature:API:Session:NotificationsConfig]

### DIFF
--- a/lib/mri/neo4j/driver/bolt/protocol/base.rb
+++ b/lib/mri/neo4j/driver/bolt/protocol/base.rb
@@ -64,14 +64,19 @@ module Neo4j
           # no `db` (3.0 is single-database). The `db` strip is keyed on
           # supports_multiple_databases? so it is automatic for V3.
 
-          def build_run(query, parameters, extra)
+          # `notification_config` is the SESSION's NotificationsConfig (the
+          # driver's rides on HELLO). It reaches the wire only on V5_2+, where
+          # notification_config_extra emits the keys; `.compact` there drops an
+          # unset severity while keeping an explicit `disabled_categories: []`.
+          def build_run(query, parameters, extra, notification_config: nil)
             enforce_impersonation_support!(extra[:imp_user])
-            Message.run(query, parameters, strip_db(extra))
+            Message.run(query, parameters,
+                        strip_db(extra).merge(notification_config_extra(notification_config).compact))
           end
 
-          def build_begin(extra)
+          def build_begin(extra, notification_config: nil)
             enforce_impersonation_support!(extra[:imp_user])
-            Message.begin_transaction(strip_db(extra))
+            Message.begin_transaction(strip_db(extra).merge(notification_config_extra(notification_config).compact))
           end
 
           # 4.0+ PULL carries `{n, qid}`. V3 overrides to the

--- a/lib/mri/neo4j/driver/session.rb
+++ b/lib/mri/neo4j/driver/session.rb
@@ -84,7 +84,10 @@ module Neo4j
             # TELEMETRY 2 = auto-commit, pipelined ahead of RUN when the server
             # opted in and the driver didn't disable it; its SUCCESS is read first.
             telemetry_sent = connection.telemetry(2, disabled: @options[:telemetry_disabled])
-            connection.send_message(connection.protocol.build_run(query, parameters, run_extra))
+            # Auto-commit RUN carries this session's NotificationsConfig (5.2+);
+            # the tx path puts it on BEGIN instead. nil / non-5.2 => absent.
+            connection.send_message(connection.protocol.build_run(query, parameters, run_extra,
+                                                                  notification_config: @options[:notification_config]))
             connection.send_message(connection.protocol.build_pull(n: fetch_size), handler)
             connection.flush
             connection.fetch_response.assert_success! if telemetry_sent

--- a/lib/mri/neo4j/driver/transaction.rb
+++ b/lib/mri/neo4j/driver/transaction.rb
@@ -41,7 +41,10 @@ module Neo4j
         # the server opted in and the driver didn't disable it; its SUCCESS is
         # read first.
         telemetry_sent = @connection.telemetry(telemetry_api, disabled: options[:telemetry_disabled])
-        @connection.send_message(@connection.protocol.build_begin(begin_extra))
+        # Session-level NotificationsConfig rides on BEGIN (5.2+); the tx's own
+        # RUNs carry none. nil / pre-5.2 => no notification keys on the wire.
+        @connection.send_message(@connection.protocol.build_begin(begin_extra,
+                                                                  notification_config: options[:notification_config]))
         @connection.flush
 
         if telemetry_sent

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -95,7 +95,7 @@ module TestkitBackend
         'Feature:API:Result.SingleOptional'                 => '',
         'Feature:API:RetryableExceptions'                   => 'ja',
         'Feature:API:Session:AuthConfig'                    => 'jar',
-        'Feature:API:Session:NotificationsConfig'           => 'ja',
+        'Feature:API:Session:NotificationsConfig'           => 'jar',
         'Feature:API:SSLClientCertificate'                  => 'ja', # JRuby: ClientCertificateManager via DriverFactory; MRI mTLS not wired
         'Feature:API:SSLConfig'                             => 'jar',
         'Feature:API:SSLSchemes'                            => 'jar',


### PR DESCRIPTION
First of the `j`-but-missing-`r` parity features. Extends #415 (driver-level NotificationsConfig, carried on HELLO) to the **session** level.

## Wire semantics (from the testkit scripts)
- Session config rides on the **first message** of the operation: the **auto-commit RUN** for `session.run`, or **BEGIN** for a transaction. The tx's own RUNs carry nothing — same placement as `tx_metadata`/`tx_timeout`.
- **Override** case: driver config on HELLO *and* session config on BEGIN/RUN coexist (`notifications_config_override_session_*` scripts assert both).

## Implementation
- `build_run` / `build_begin` gain an optional `notification_config:` and merge the same version-gated `notification_config_extra` hook HELLO already uses — so keys reach the wire **only on Bolt 5.2+** (a no-op on older protocols and when the session sets nothing). `.compact` drops an unset severity while keeping an explicit `disabled_categories: []`.
- `Session#run` and `Transaction` (on BEGIN) pass `@options[:notification_config]`. Override falls out of the existing option-bag split: **HELLO** reads the *connection's* (driver-level) options; **BEGIN/RUN** read the *session's* merged options. A session that sets its own config overrides for its queries; one that doesn't sends nothing (driver config still applies via HELLO).
- Advertise `Feature:API:Session:NotificationsConfig` on MRI (`'ja'` → `'jar'`).

The backend already builds session `notification_config` (`new_session.rb`), so no backend change.

## Validation (rust boltstub, local MRI backend)
- `test_session_notifications_config` — all **6** (config on run / begin / read_tx, and session-overrides-driver on each) ✅
- Full `notifications_config` 8/0 (driver + session + mapping); `tx_run` / `iteration` / `summary` 158/0; `session_run`/iteration 29/0; MRI unit specs 66/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)