### PR TITLE
[DO NOT MERGE] Validate require-green gate blocks a subTest failure

### DIFF
--- a/lib/mri/neo4j/driver/summary/result_summary.rb
+++ b/lib/mri/neo4j/driver/summary/result_summary.rb
@@ -29,7 +29,12 @@ module Neo4j
           return nil unless @metadata.key?(:type)
 
           case @metadata[:type]
-          when 'r' then QueryType::READ_ONLY
+          # !!! DELIBERATE BUG — DO NOT MERGE (PR #NNN gate-validation) !!!
+          # Maps read summaries to WRITE_ONLY so the query_type="r" subTest of
+          # test_can_obtain_summary_type fails. Proves the require-green gate
+          # catches a subTest failure (the exact blind spot the old baseline
+          # gate missed). Revert = restore `QueryType::READ_ONLY`.
+          when 'r' then QueryType::WRITE_ONLY
           when 'w' then QueryType::WRITE_ONLY
           when 'rw' then QueryType::READ_WRITE
           when 's' then QueryType::SCHEMA_WRITE


### PR DESCRIPTION
**Deliberately failing PR — please close unmerged.** Requested as proof that the require-green gate (PR #420) actually blocks a red run.

## The deliberate break
One line in `Summary#query_type`: read summaries (`'r'`) map to `WRITE_ONLY`. This makes the `query_type='r'` **subTest** of `tests.stub.summary.test_summary.TestSummaryBasicInfo.test_query` fail its `assertEqual(summary.query_type, query_type)`.

## Why a subTest specifically
This is the exact blind spot the old baseline gate had. Verified locally:

```
FAIL: test_query (...TestSummaryBasicInfo) (query_type='r')
Ran 1 test — FAILED (failures=1)

inline " ... FAIL" tokens in the log: 0
```

- **Old baseline gate** keyed on inline ` ... FAIL` tokens → **0 found** → it would have reported this run **green**.
- **New require-green gate** parses unittest's own `FAILED (failures=1)` summary → **red**, and lists `FAIL: ... (query_type='r')` in the step summary.

## What to look for in CI
The **`testkit-stub (mri)`** job should go **red** (it's the blocking gate), with the require-green step failing and the failing subTest listed. Other flavors will show the same failure (also blocking now, per the all-flavors-block change).

Once you've seen it red, close this PR unmerged. Revert = restore `when 'r' then QueryType::READ_ONLY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)