### PR TITLE
feat(mri): advertise Optimization:PullPipelining

### DIFF
--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -122,7 +122,7 @@ module TestkitBackend
         'Optimization:MinimalBookmarksSet'                  => '',
         'Optimization:MinimalResets'                        => '',  # disabled in Java too
         'Optimization:MinimalVerifyAuthentication'          => '',
-        'Optimization:PullPipelining'                       => 'ja',
+        'Optimization:PullPipelining'                       => 'jar',
         'Optimization:ResultListFetchAll'                   => 'ja',
 
         # --- Backend / detail ------------------------------------------------


### PR DESCRIPTION
Next `j`-but-missing-`r` feature. **Verify-and-advertise** — no driver change.

MRI's `Session#run` and `Transaction#run` already enqueue the `PULL` right after the `RUN` and send both in one `flush`, so the server receives them pipelined. testkit's `test_pull_pipelining` asserts exactly that wire pattern across read/write × tx/auto-commit, and it passes as-is — the flag just wasn't advertised.

## Validation (rust boltstub)
- `test_optimizations.test_pull_pipelining` ✅ (all 4 subtests)
- Full `optimizations` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)