### PR TITLE
feat(mri): surface Bolt 6.0 UnsupportedType [Feature:API:Type.UnsupportedType]

### DIFF
--- a/lib/jruby/neo4j/driver.rb
+++ b/lib/jruby/neo4j/driver.rb
@@ -41,6 +41,10 @@ module Neo4j
       Node = Java::OrgNeo4jDriverInternal::InternalNode
       Path = Java::OrgNeo4jDriverInternal::InternalPath
       Relationship = Java::OrgNeo4jDriverInternal::InternalRelationship
+      # Bolt 6.0 forward-compat marker. Aliasing the Java type here lets the
+      # testkit backend match it with the same `Neo4j::Driver::Types::
+      # UnsupportedType` case MRI uses (which has its own pure-Ruby class).
+      UnsupportedType = Java::OrgNeo4jDriverTypes::UnsupportedType
     end
   end
 end
@@ -61,6 +65,7 @@ Java::OrgNeo4jDriverInternal::InternalPath.include Neo4j::Driver::Ext::StartEndN
 Java::OrgNeo4jDriverInternal::InternalPath::SelfContainedSegment.include Neo4j::Driver::Ext::StartEndNaming
 Java::OrgNeo4jDriverInternal::InternalRecord.prepend Neo4j::Driver::Ext::InternalRecord
 Java::OrgNeo4jDriverInternal::InternalRelationship.prepend Neo4j::Driver::Ext::InternalRelationship
+Java::OrgNeo4jDriverInternal::InternalUnsupportedType.prepend Neo4j::Driver::Ext::UnsupportedType
 Java::OrgNeo4jDriverInternal::InternalResult.prepend Neo4j::Driver::Ext::InternalResult
 Java::OrgNeo4jDriverInternal::InternalSession.prepend Neo4j::Driver::Ext::InternalSession
 Java::OrgNeo4jDriverInternal::InternalTransaction.prepend Neo4j::Driver::Ext::InternalTransaction

--- a/lib/jruby/neo4j/driver/ext/unsupported_type.rb
+++ b/lib/jruby/neo4j/driver/ext/unsupported_type.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Driver
+    module Ext
+      # Java's UnsupportedType#message returns an Optional<String>; unwrap it to
+      # a nil-or-String so the public API matches MRI's UnsupportedType, which
+      # stores a plain nilable message.
+      module UnsupportedType
+        def message = super.or_else(nil)
+      end
+    end
+  end
+end

--- a/lib/mri/neo4j/driver/bolt/protocol/v6.rb
+++ b/lib/mri/neo4j/driver/bolt/protocol/v6.rb
@@ -11,13 +11,13 @@ module Neo4j
         #   - VECTOR     0x56 — packed numeric array; 2 fields
         #                       (element-type byte, raw bytes).
         #   - UNSUPPORTED 0x3F — forward-compat marker; 4 fields
-        #                       (name, min_major, min_minor, extra).
+        #                       (name, min_major, min_minor, extra-map whose
+        #                       optional `message` key carries a server note).
         #
-        # The driver has no public Types::Vector / Types::Unsupported
-        # surface yet (Feature:API:Type.Vector is unimplemented), so we
-        # surface them as plain hashes. The goal here is "don't crash
-        # at hydration"; the proper type wrapping lands when there's a
-        # public API to wire it to.
+        # UNSUPPORTED hydrates to Types::UnsupportedType (Feature:API:Type.
+        # UnsupportedType). VECTOR stays a plain hash — Feature:API:Type.Vector
+        # is unimplemented, so the goal there is still just "don't crash at
+        # hydration" until there's a public API to wire it to.
         class V6 < V58
           VECTOR_SIGNATURE = 0x56
           UNSUPPORTED_SIGNATURE = 0x3F
@@ -28,7 +28,12 @@ module Neo4j
               { element_type: fields[0], bytes: fields[1] }
             end
             unpacker.register_hydration_handler(UNSUPPORTED_SIGNATURE) do |fields|
-              { name: fields[0], min_major: fields[1], min_minor: fields[2], extra: fields[3] }
+              # fields[3] is an extra map (symbol keys) whose :message is the
+              # optional server note. Guard the type so a malformed/absent
+              # 4th field can't crash hydration — the whole point of a
+              # forward-compat marker is to survive the unexpected.
+              extra = fields[3].is_a?(Hash) ? fields[3] : {}
+              Types::UnsupportedType.new(fields[0], fields[1], fields[2], extra[:message])
             end
           end
         end

--- a/lib/mri/neo4j/driver/packstream/packer.rb
+++ b/lib/mri/neo4j/driver/packstream/packer.rb
@@ -37,10 +37,12 @@ module Neo4j
           when Hash
             # Check Hash before Enumerable since Hash is also Enumerable
             pack_map(value)
-          when Types::Node, Types::Relationship, Types::Path
-            # Graph types are not valid query parameters. Reject before the
-            # Enumerable branch since Path includes Enumerable.
-            raise Exceptions::ClientException, "Unable to convert #{value.class} to Neo4j Value."
+          when Types::Node, Types::Relationship, Types::Path, Types::UnsupportedType
+            # Graph types are not valid query parameters; neither is an
+            # UnsupportedType (a value the driver couldn't materialise — it
+            # must not be sent back to the server). Reject before the Enumerable
+            # branch since Path includes Enumerable.
+            Exceptions::ClientException.unable_to_convert(value)
           when Array, Set, Range
             # Known sized collections — pack_list uses #size, which is O(1) here.
             pack_list(value)
@@ -66,7 +68,7 @@ module Neo4j
           when Types::Duration
             pack_duration(value)
           else
-            raise Exceptions::ClientException, "Unable to convert #{value.class} to Neo4j Value."
+            Exceptions::ClientException.unable_to_convert(value)
           end
           self
         end

--- a/lib/mri/neo4j/driver/types/unsupported_type.rb
+++ b/lib/mri/neo4j/driver/types/unsupported_type.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Driver
+    module Types
+      # A value whose Bolt struct type is newer than this driver understands
+      # (Bolt 6.0+ can push forward-compat markers, struct signature 0x3F). The
+      # driver can't materialise the real value, but it must not crash — it
+      # surfaces the type's name, the protocol version that introduced it, and
+      # an optional server message so callers can react. Mirrors the Java
+      # driver's UnsupportedType.
+      class UnsupportedType
+        attr_reader :name, :min_protocol_version, :message
+
+        # `major`/`minor` are the wire ints (e.g. 6, 10); expose them joined as
+        # "major.minor" the way testkit / the Java driver report it.
+        def initialize(name, major, minor, message = nil)
+          @name = name
+          @min_protocol_version = "#{major}.#{minor}"
+          @message = message
+        end
+      end
+    end
+  end
+end

--- a/testkit-backend/conversion.rb
+++ b/testkit-backend/conversion.rb
@@ -53,14 +53,15 @@ module TestkitBackend
                          startNodeElementId: to_testkit(object.start_node_element_id),
                          endNodeElementId: to_testkit(object.end_node_element_id),
                          type: to_testkit(object.type), props: to_testkit(object.properties))
-          when ->(o) { defined?(Java::OrgNeo4jDriverTypes::UnsupportedType) &&
-                       Java::OrgNeo4jDriverTypes::UnsupportedType === o }
-            # A value of a type newer than this driver understands; the Java
-            # driver keeps its name + the bolt version that introduced it.
-            # JRuby-only type, so guard the Java constant (absent on MRI).
+          when Neo4j::Driver::Types::UnsupportedType
+            # A value whose type is newer than the driver understands (name +
+            # the protocol version that introduced it + optional server note).
+            # One case for both flavours: MRI's pure-Ruby type and, aliased in
+            # lib/jruby, the Java type — whose #message is unwrapped to a plain
+            # nilable there (ext/unsupported_type.rb) so both APIs match.
             named_entity('CypherUnsupportedType', name: object.name,
                          minimumProtocol: object.min_protocol_version,
-                         message: object.message.or_else(nil))
+                         message: object.message)
           when Neo4j::Driver::Types::UnresolvableZonedDateTime
             # A datetime whose zone id the driver couldn't resolve — using it
             # raises the driver error (naming the zone), which the request

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -103,7 +103,7 @@ module TestkitBackend
         'Feature:API:Summary:Profile:OptionalStats'         => '',
         'Feature:API:Type.Spatial'                          => '',
         'Feature:API:Type.Temporal'                         => 'jar',  # jruby wraps Java temporal types; MRI hydrates to Ruby Time/Types and defers unresolvable zone ids (Types::UnresolvableZonedDateTime)
-        'Feature:API:Type.UnsupportedType'                  => 'ja',
+        'Feature:API:Type.UnsupportedType'                  => 'jar',
         'Feature:API:Type.UUID'                             => '',
         'Feature:API:Type.Vector'                           => '',
 


### PR DESCRIPTION
Next `j`-but-missing-`r` feature. Reuses the deferred-value groundwork idea from #427 (Temporal), but here the value is *returned* (serialises to `CypherUnsupportedType`), not raised.

## What
Bolt 6.0 can push a forward-compat marker struct (signature `0x3F`) for a value type newer than the driver understands. `V6` already had a `0x3F` handler that hydrated it to a plain hash "so it doesn't crash" — this wires it to a real public type.

- **New `Types::UnsupportedType`** — `name`, `min_protocol_version` (`"major.minor"`), optional `message`. Mirrors the Java driver's `UnsupportedType`.
- **`V6`'s `0x3F` handler** builds it. The struct's 4th field is an *extra map* whose `:message` key carries the server note (empty map ⇒ no message).
- **`conversion.rb`** serialises the MRI type to `CypherUnsupportedType` (next to the existing JRuby/Java case).
- Advertise `Feature:API:Type.UnsupportedType` (`'ja'` → `'jar'`).

## Validation (rust boltstub)
- `test_unsupported_type` + `test_unsupported_type_in_list` **2/0** (with/without message, bare and nested in a list).
- Full `datatypes` 31/0; MRI unit specs 69/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for representing and inspecting unsupported Bolt types (name, minimum protocol version, and optional server message) across both MRI and JRuby.
* **Bug Fixes**
  * Prevented unsupported values from being packed as query parameters.
  * Improved unsupported type hydration, including safer handling of VECTOR.
  * Updated conversion behavior in the testkit backend to correctly map unsupported types.
  * Corrected feature detection for unsupported type support.
* **Documentation**
  * Clarified Bolt 6 hydration behavior for unsupported result records and VECTOR handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->