### PR TITLE
feat(mri): per-query auth for execute_query [Feature:API:Driver.ExecuteQuery:WithAuth]

### DIFF
--- a/lib/mri/neo4j/driver/driver.rb
+++ b/lib/mri/neo4j/driver/driver.rb
@@ -133,20 +133,24 @@ module Neo4j
       #                          query-log / monitoring tooling.
       #   :timeout             — seconds (or ActiveSupport::Duration);
       #                          server-side transaction timeout.
-      #   :auth_token          — accepted but not yet honoured —
-      #                          per-call auth is its own slice
-      #                          (Bolt 5.1+ LOGOFF/LOGON).
+      #   :auth_token          — run this query under a specific identity
+      #                          (Bolt 5.1+ re-auths the connection via
+      #                          LOGOFF/LOGON); omit to use the driver's.
       def execute_query(cypher, params = {}, config = {})
         routing = config[:routing] || RoutingControl::WRITE
 
         # `bookmark_manager: nil` is meaningful (explicitly disables the
         # manager) and differs from omitting the key, so it's added
         # conditionally rather than via .compact. `:database` /
-        # `:impersonated_user` keep .compact semantics (nil == omitted).
+        # `:impersonated_user` / `:auth_token` keep .compact semantics
+        # (nil == omitted). A per-query `:auth_token` pins the session (and so
+        # its connection) to that identity — the provider re-auths on Bolt 5.1+
+        # (Feature:API:Driver.ExecuteQuery:WithAuth).
         session_opts = {
           database: config[:database],
           default_access_mode: routing,
-          impersonated_user: config[:impersonated_user]
+          impersonated_user: config[:impersonated_user],
+          auth_token: config[:auth_token]
         }.compact
         # execute_query chains bookmarks across successive calls via a
         # driver-wide default BookmarkManager, so a read after a write sees

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -74,7 +74,7 @@ module TestkitBackend
         'Feature:API:BookmarkManager'                       => 'jar',
         'Feature:API:ConnectionAcquisitionTimeout'          => 'jar',
         'Feature:API:Driver.ExecuteQuery'                   => 'jar',
-        'Feature:API:Driver.ExecuteQuery:WithAuth'          => 'ja',
+        'Feature:API:Driver.ExecuteQuery:WithAuth'          => 'jar',
         'Feature:API:Driver:GetServerInfo'                  => '',
         'Feature:API:Driver.IsEncrypted'                    => 'jar',
         'Feature:API:Driver:NotificationsConfig'            => 'jar',


### PR DESCRIPTION
Follow-on to ExecuteQuery (#423, merged), now unblocked.

## What
The MRI session already honours a per-session `:auth_token` — it pins the acquired connection's identity and re-auths on Bolt 5.1+ (that's `Feature:API:Session:AuthConfig`, already advertised). `execute_query` simply wasn't threading `config[:auth_token]` into the session it builds, so per-query auth was "accepted but ignored".

- `execute_query` now adds `auth_token: config[:auth_token]` to its session options (compacted — nil ⇒ use the driver's identity).
- The backend already converts `config[:authorizationToken]` → an `AuthToken`, so **no backend change**.
- Advertise `Feature:API:Driver.ExecuteQuery:WithAuth` (`'ja'` → `'jar'`).

## Validation (rust boltstub)
- `driver_execute_query` **15/0** — `test_configure_auth` and `test_configure_re_auth` (previously skipped) now run and pass, including the re-auth-between-calls case.
- `homedb` 37/0; MRI unit specs 69/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)