### PR TITLE
feat(mri): advertise Feature:API:RetryableExceptions

### DIFF
--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -93,7 +93,7 @@ module TestkitBackend
         'Feature:API:Result.Peek'                           => 'jar',
         'Feature:API:Result.Single'                         => 'jar',
         'Feature:API:Result.SingleOptional'                 => '',
-        'Feature:API:RetryableExceptions'                   => 'ja',
+        'Feature:API:RetryableExceptions'                   => 'jar',
         'Feature:API:Session:AuthConfig'                    => 'jar',
         'Feature:API:Session:NotificationsConfig'           => 'jar',
         'Feature:API:SSLClientCertificate'                  => 'ja', # JRuby: ClientCertificateManager via DriverFactory; MRI mTLS not wired


### PR DESCRIPTION
**Verify-and-advertise** — no driver change.

testkit gates an *in-test* assertion on this feature — `if driver_supports(RETRYABLE_EXCEPTIONS): assertEqual(exc.retryable, expected)` — across the errors, retry, tx_lifetime, execute_query and authorization suites. MRI already produces the right answer:

- The error mapper classifies `Neo.TransientError.*` as `TransientException` and `Neo.ClientError.*` as `ClientException`.
- The testkit backend's `DriverError` already computes `retryable` for the retryable set (`Transient` / `ServiceUnavailable` / `SecurityRetryable` / `AuthorizationExpired`).

The flag just wasn't advertised, so those assertions were skipped.

## Validation (rust boltstub, assertions now active)
- `errors` 8/0 (incl. `test_error_retryable`: `Neo.ClientError.*`→False, `Neo.TransientError.*`→True)
- `retry` 6/0, `tx_lifetime` 1/0, `driver_execute_query` 15/0, `authorization` 113/0
- MRI unit specs 69/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)