### PR TITLE
feat(mri): backfill GQL status objects for pre-5.6 servers [Feature:API:Summary:GqlStatusObjects]

### DIFF
--- a/lib/mri/neo4j/driver/result.rb
+++ b/lib/mri/neo4j/driver/result.rb
@@ -39,6 +39,7 @@ module Neo4j
         @on_summary = on_summary  # called with the built Summary when the stream ends in SUCCESS
         @on_release = on_release  # called once when the connection is no longer needed
         @records = []       # records pulled into memory by #buffer (not by iteration)
+        @had_record = false # any RECORD arrived on this stream — drives the GQL outcome status
         @summary = nil
         @consumed = false   # stream fully drained (terminal seen)
         @discarded = false  # records explicitly released; further access raises
@@ -255,11 +256,13 @@ module Neo4j
       end
 
       def build_record(msg)
+        @had_record = true
         Record.new(@keys, msg.fields)
       end
 
       def finalize(metadata)
-        @summary = Summary::ResultSummary.new(@run_metadata.merge(metadata), @query_text, @parameters, @connection)
+        @summary = Summary::ResultSummary.new(@run_metadata.merge(metadata), @query_text, @parameters, @connection,
+                                              had_record: @had_record)
         @consumed = true
       end
 

--- a/lib/mri/neo4j/driver/summary/result_summary.rb
+++ b/lib/mri/neo4j/driver/summary/result_summary.rb
@@ -151,14 +151,17 @@ module Neo4j
         # else -> 03N42; the notification facets move into the diagnostic
         # record under `_severity` / `_classification` / `_position`.
         def notification_as_status(notification)
-          warning = notification[:severity] == 'WARNING'
+          # Old wire format carries :severity, newer :severityLevel — read both,
+          # matching Summary::Notification.
+          severity = notification[:severityLevel] || notification[:severity]
+          warning = severity == 'WARNING'
           description = notification[:description] unless notification[:description] == 'null'
           {
             gql_status: warning ? '01N42' : '03N42',
             status_description: description || (warning ? 'warn: unknown warning' : 'info: unknown notification'),
             neo4j_code: notification[:code],
             title: notification[:title],
-            diagnostic_record: { _severity: notification[:severity], _classification: notification[:category],
+            diagnostic_record: { _severity: severity, _classification: notification[:category],
                                  _position: notification[:position] }.compact
           }
         end

--- a/lib/mri/neo4j/driver/summary/result_summary.rb
+++ b/lib/mri/neo4j/driver/summary/result_summary.rb
@@ -151,9 +151,10 @@ module Neo4j
         # else -> 03N42; the notification facets move into the diagnostic
         # record under `_severity` / `_classification` / `_position`.
         def notification_as_status(notification)
-          # Old wire format carries :severity, newer :severityLevel — read both,
-          # matching Summary::Notification.
-          severity = notification[:severityLevel] || notification[:severity]
+          # Legacy notifications carry severity under :severity — the only key
+          # the Java driver's MetadataExtractor reads here; :severityLevel never
+          # appears on this wire structure.
+          severity = notification[:severity]
           warning = severity == 'WARNING'
           description = notification[:description] unless notification[:description] == 'null'
           {

--- a/lib/mri/neo4j/driver/summary/result_summary.rb
+++ b/lib/mri/neo4j/driver/summary/result_summary.rb
@@ -8,11 +8,12 @@ module Neo4j
       # the namespace; no public `metadata` accessor, no Bolt-wire-format
       # leakage.
       class ResultSummary
-        def initialize(metadata, query_text = nil, parameters = {}, connection = nil)
+        def initialize(metadata, query_text = nil, parameters = {}, connection = nil, had_record: false)
           @metadata = metadata
           @query_text = query_text
           @parameters = parameters
           @connection = connection
+          @had_record = had_record
         end
 
         def query
@@ -105,20 +106,73 @@ module Neo4j
             .map { |n| Notification.new(n) }
         end
 
-        # GQL status objects, as reported natively by Bolt 5.6+ servers in
-        # the summary `statuses` list (preserving server order — the driver
-        # must not reorder them). A status carrying a `neo4j_code` is also a
-        # notification (GqlNotification); the rest are plain status objects.
-        # The pre-5.6 backfill (Feature:API:Summary:GqlStatusObjects, which
-        # synthesises statuses from notifications) isn't implemented, so it
-        # stays unadvertised.
+        # GQL status objects. Bolt 5.6+ servers report them natively in the
+        # summary `statuses` list, which we preserve verbatim (server order —
+        # the driver must not reorder them). Older servers (or any SUCCESS
+        # without `statuses`) don't, so we synthesise the list from the legacy
+        # `notifications` plus a mandatory outcome status — the pre-5.6
+        # backfill. A status carrying a `neo4j_code` is also a notification
+        # (GqlNotification); the rest are plain status objects.
         def gql_status_objects
-          (@metadata[:statuses] || []).map do |status|
+          (@metadata[:statuses] || polyfilled_statuses).map do |status|
             (status[:neo4j_code] ? GqlNotification : GqlStatusObject).new(status)
           end
         end
 
         private
+
+        # Synthesise `statuses` from the legacy `notifications` list plus a
+        # single outcome status, mirroring the Java driver's MetadataExtractor.
+        # The whole set is ordered by GQL status class (02 no-data, 01 warning,
+        # 00 success, 03 info, then everything else); the sort is stable so
+        # same-class notifications keep their server order.
+        def polyfilled_statuses
+          statuses = (@metadata[:notifications] || []).map { notification_as_status(it) }
+          statuses << outcome_status
+          statuses.each_with_index.sort_by { |status, i| [gql_status_class(status), i] }.map(&:first)
+        end
+
+        # The mandatory outcome status. The driver reached the summary having
+        # streamed the whole result (eager pull), so it knows whether a record
+        # arrived: yes -> successful completion; no -> "no data", or "omitted
+        # result" when the query produced no fields at all (e.g. a write).
+        def outcome_status
+          if @had_record
+            { gql_status: '00000', status_description: 'note: successful completion' }
+          elsif Array(@metadata[:fields]).empty?
+            { gql_status: '00001', status_description: 'note: successful completion - omitted result' }
+          else
+            { gql_status: '02000', status_description: 'note: no data' }
+          end
+        end
+
+        # Reshape one legacy notification into a `statuses`-list entry so it
+        # flows through GqlNotification unchanged. WARNING -> 01N42, everything
+        # else -> 03N42; the notification facets move into the diagnostic
+        # record under `_severity` / `_classification` / `_position`.
+        def notification_as_status(notification)
+          warning = notification[:severity] == 'WARNING'
+          description = notification[:description] unless notification[:description] == 'null'
+          {
+            gql_status: warning ? '01N42' : '03N42',
+            status_description: description || (warning ? 'warn: unknown warning' : 'info: unknown notification'),
+            neo4j_code: notification[:code],
+            title: notification[:title],
+            diagnostic_record: { _severity: notification[:severity], _classification: notification[:category],
+                                 _position: notification[:position] }.compact
+          }
+        end
+
+        # Sort key from the GQL status class (first two chars of the code).
+        def gql_status_class(status)
+          case status[:gql_status]
+          when /\A02/ then 0
+          when /\A01/ then 1
+          when /\A00/ then 2
+          when /\A03/ then 3
+          else 4
+          end
+        end
 
         def statuses_as_notifications
           (@metadata[:statuses] || []).filter_map do |s|

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -99,7 +99,7 @@ module TestkitBackend
         'Feature:API:SSLClientCertificate'                  => 'ja', # JRuby: ClientCertificateManager via DriverFactory; MRI mTLS not wired
         'Feature:API:SSLConfig'                             => 'jar',
         'Feature:API:SSLSchemes'                            => 'jar',
-        'Feature:API:Summary:GqlStatusObjects'              => 'ja',
+        'Feature:API:Summary:GqlStatusObjects'              => 'jar',
         'Feature:API:Summary:Profile:OptionalStats'         => '',
         'Feature:API:Type.Spatial'                          => '',
         'Feature:API:Type.Temporal'                         => 'jar',  # jruby wraps Java temporal types; MRI hydrates to Ruby Time/Types and defers unresolvable zone ids (Types::UnresolvableZonedDateTime)


### PR DESCRIPTION
Closes the MRI gap on `Feature:API:Summary:GqlStatusObjects` (JRuby already advertises it; MRI now does too — `ja` → `jar`).

## What

Bolt 5.6+ servers report GQL status objects natively in the summary `statuses` list, which `ResultSummary#gql_status_objects` already surfaces. Older servers send only the legacy `notifications`, so — mirroring the Java driver's `MetadataExtractor` — the driver now synthesises the `statuses` list from those notifications plus a mandatory **outcome status**.

- **notification → status**: `WARNING` → `01N42`, everything else → `03N42`; the notification facets move into the diagnostic record (`_severity` / `_classification` / `_position`) so each reuses the existing `GqlNotification` unchanged. Missing description falls back to `"warn: unknown warning"` / `"info: unknown notification"`.
- **outcome status**: the driver eagerly pulls the whole result, so it knows whether a record arrived. `Result` tracks `had_record` and passes it to the summary — record seen → `00000` successful completion; none → `02000` no data, or `00001` omitted result when the query produced no fields (e.g. a write).
- **ordering**: the synthesised set is stable-sorted by GQL status class (`02` no-data, `01` warning, `00` success, `03` info, then the rest), matching the Java `TreeSet` comparator — so a no-data outcome sorts before a warning while a success sorts after it. The native 5.6 path is untouched and preserves server order.

## Testing

rust boltstub (`TEST_RUSTY_STUB=true`, MRI backend):
- `tests.stub.summary` — 132 pass, incl. `TestSummaryGqlStatusObjects4x4` (backfill) + `5x6` (native) and their `Discard` variants (2 testkit-side skips, same on JRuby)
- `tests.stub.iteration` — 56/0
- MRI unit specs — 69/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved GQL status reporting for query results.
  - Results now distinguish between successful outcomes that returned data and those with no returned records.
  - Legacy notifications are converted into complete outcome statuses when native GQL statuses are unavailable.
  - Statuses are consistently ordered while preserving server-provided status details.
- **Compatibility**
  - Updated feature detection so supported Java integrations correctly advertise GQL status object support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->