### PR TITLE
feat(mri): honour connection.recv_timeout_seconds hint [ConfHint:connection.recv_timeout_seconds]

### DIFF
--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -136,7 +136,7 @@ module TestkitBackend
         # ClusterComposition parameters not yet wired from Ruby), so only
         # MRI advertises it.
         'Backend:RTForceUpdate'                             => 'r',
-        'ConfHint:connection.recv_timeout_seconds'          => 'ja',
+        'ConfHint:connection.recv_timeout_seconds'          => 'jar',
         'Detail:ClosedDriverIsEncrypted'                    => '',
         'Detail:DefaultSecurityConfigValueEquality'         => 'ja',
         'Detail:NumberIsNumber'                             => 'jr'


### PR DESCRIPTION
Closes the MRI gap on `ConfHint:connection.recv_timeout_seconds` (`ja` → `jar`).

## What

The recv-timeout machinery was fully wired during the pipelined-connection refactor but deliberately left **unadvertised** — that slice kept its scope to "fix existing features, no new feature surface." Everything is already in place in `bolt/connection.rb`:

- HELLO `hints.connection.recv_timeout_seconds` parsed (`apply_recv_timeout_hint`)
- applied as the per-read socket timeout in the reader's advance loop (`current_read_timeout` → `wait_readable(timeout)`)
- on timeout: raises `ConnectionReadTimeoutException`, marks the connection broken, and fans the failure out to all waiters
- NOOP keepalives reset the window (an in-time request survives)

This just flips the flag on.

## Testing

rust boltstub (`TEST_RUSTY_STUB=true`, MRI backend): `tests.stub.configuration_hints` **14/14** — direct + routing recv-timeout, in-time NOOP keepalives, unmanaged-tx termination (subsequent use fails), managed-tx retry. (~111s wall — the tests exercise real socket timeouts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the configuration hint feature tag so it is advertised for both JRuby/Java and Ruby drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->