### PR TITLE
feat(mri): Result#to_a pulls all records in one PULL -1 [Optimization:ResultListFetchAll]

### DIFF
--- a/lib/mri/neo4j/driver/result.rb
+++ b/lib/mri/neo4j/driver/result.rb
@@ -45,6 +45,7 @@ module Neo4j
         @discarded = false  # records explicitly released; further access raises
         @failed = false     # stream ended with a server FAILURE; connection needs RESET
         @cancelling = false # consume(): abandon the rest — DISCARD the next batch instead of PULL
+        @list_mode = false  # to_a/list: pull all remaining in one PULL {n: -1}, ignoring fetch_size
         @peeked_record = nil
       end
 
@@ -107,6 +108,10 @@ module Neo4j
       def to_a
         raise Exceptions::ResultConsumedException if @discarded
 
+        # Result.list ignores the configured fetch size: pull everything still on
+        # the server in a single PULL {n: -1} instead of paging (Optimization:
+        # ResultListFetchAll). The next watermark pull picks this up.
+        @list_mode = true
         records = []
         records << self.next while has_next?
         records
@@ -238,7 +243,9 @@ module Neo4j
         # and single-result transactions never demote, so they keep sending the
         # bare {n} the stub scripts expect (qid is optional there).
         extra = @demoted && @qid ? { qid: @qid } : {}
-        message = @cancelling ? @connection.protocol.build_discard(extra) : @connection.protocol.build_pull(extra.merge(n: @fetch_size))
+        # list mode pulls all remaining records at once (n: -1); otherwise page by fetch_size.
+        n = @list_mode ? -1 : @fetch_size
+        message = @cancelling ? @connection.protocol.build_discard(extra) : @connection.protocol.build_pull(extra.merge(n:))
         @connection.send_message(message, @handler)
         @connection.flush
       end

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -123,7 +123,7 @@ module TestkitBackend
         'Optimization:MinimalResets'                        => '',  # disabled in Java too
         'Optimization:MinimalVerifyAuthentication'          => '',
         'Optimization:PullPipelining'                       => 'jar',
-        'Optimization:ResultListFetchAll'                   => 'ja',
+        'Optimization:ResultListFetchAll'                   => 'jar',
 
         # --- Backend / detail ------------------------------------------------
         'Backend:MockTime'                                  => 'jar',


### PR DESCRIPTION
Closes the MRI gap on `Optimization:ResultListFetchAll` (`ja` → `jar`).

## What

`Result.list` ignores the configured fetch size and pulls everything still on the server in a single `PULL {n: -1}` instead of paging. `Result#to_a` now flips the cursor into "list mode": the next watermark pull sends `n: -1`, so after the RUN-pipelined first batch the driver fetches the remainder in one go. This matches the "pipelining one PULL" branch of the stub scripts (`PULL {n: fetch_size}` then `PULL {n: -1}`).

Streaming iteration (`each`/`next`) is unchanged — still `fetch_size`-paged.

- `request_more` sends `n: -1` in list mode; `RecordBuffer` already handles a single unbounded batch (its watermarks are sized for `-1`).

## Testing

rust boltstub (MRI backend):
- `tests.stub.iteration.test_result_list` — all `*_result_list_pulls_all_records_at_once` and `*_next_before_list` variants pass across `session.run` / `tx.run` / tx-func
- Regression: `iteration` 56/0, `tx_run` 19/0, `driver_execute_query` 15/0 (execute_query's internal `to_a` now pulls `-1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)