### PR TITLE
feat(mri): retry idempotent auto-commit RUN once [Feature:IdempotentRetries]

### DIFF
--- a/lib/mri/neo4j/driver/auto_commit_retries_mode.rb
+++ b/lib/mri/neo4j/driver/auto_commit_retries_mode.rb
@@ -6,9 +6,9 @@ module Neo4j
     # (Feature:IdempotentRetries) — the MRI counterpart of the Java driver's
     # org.neo4j.driver.AutoCommitRetriesMode enum. Same constant names, MRI's
     # own (symbol) values, mirroring how AccessMode/RoutingControl are defined
-    # here. Defined so the shared testkit-backend can name the mode
-    # flavor-agnostically; the pure-Ruby Bolt 6.0 retry path is not yet
-    # implemented, so MRI does not act on it.
+    # here. Session#run acts on it (together with the driver-level
+    # `auto_commit_retries_disabled` default) to retry an idempotent auto-commit
+    # RUN once — see Session#auto_commit_retries_enabled?.
     module AutoCommitRetriesMode
       ENABLED = :enabled
       DISABLED = :disabled

--- a/lib/mri/neo4j/driver/session.rb
+++ b/lib/mri/neo4j/driver/session.rb
@@ -74,10 +74,6 @@ module Neo4j
 
         connection = acquire_connection(session_access_mode)
         fetch_size = effective_fetch_size
-        # TELEMETRY 2 = auto-commit, pipelined ahead of RUN once (not resent on an
-        # idempotent retry) when the server opted in and the driver didn't disable
-        # it; its SUCCESS is read before the RUN reply.
-        telemetry_pending = connection.telemetry(2, disabled: @options[:telemetry_disabled])
         # Feature:IdempotentRetries — an auto-commit RUN whose failure the server
         # flags `_idempotent` may be retried once: RESET clears the FAILED state
         # (and drains the pipelined PULL's IGNORED), then RUN+PULL are re-sent
@@ -86,6 +82,8 @@ module Neo4j
         retries_left = auto_commit_retries_enabled? ? 1 : 0
 
         buffer = handler = run_response = nil
+        telemetry_sent = false    # TELEMETRY 2 = auto-commit; sent once, never resent on a retry
+        telemetry_pending = false # its (opted-in) SUCCESS is still owed
         loop do
           # A fresh stream per attempt — a prior attempt's buffer saw the IGNORED.
           buffer = Bolt::RecordBuffer.new(fetch_size: fetch_size)
@@ -96,6 +94,12 @@ module Neo4j
           stage = nil
           run_response =
             begin
+              # TELEMETRY is pipelined ahead of the first RUN when the server opted
+              # in; kept inside this block so a send failure still releases the lease.
+              unless telemetry_sent
+                telemetry_sent = true
+                telemetry_pending = connection.telemetry(2, disabled: @options[:telemetry_disabled])
+              end
               # Auto-commit RUN carries this session's NotificationsConfig (5.2+);
               # the tx path puts it on BEGIN instead. nil / non-5.2 => absent.
               connection.send_message(connection.protocol.build_run(query, parameters, run_extra,
@@ -110,6 +114,13 @@ module Neo4j
               stage = :run
               connection.fetch_response.assert_success!
             rescue Exceptions::Neo4jException => e
+              # Classify first: this notifies the auth-token manager (and, for a
+              # security failure, sets auth_failed so the guards below hold) and,
+              # for routed connections, fires on_write_failure / deactivate and
+              # swaps NotALeader for SessionExpired. assert_success! raises
+              # *outside* RoutedConnection's wrapper, so this is the only place the
+              # classifier sees FAILURE responses to RUN.
+              classified = connection.classify_failure(e)
               if stage == :run && retries_left.positive? && idempotent_error?(e) && !connection.auth_failed
                 retries_left -= 1
                 # RESET clears FAILED and drains the abandoned RUN/PULL replies.
@@ -117,13 +128,6 @@ module Neo4j
                 retry_run = true
                 nil
               else
-                # Classify first: this notifies the auth-token manager (and may
-                # flag the connection for discard on an auth failure) and, for
-                # routed connections, fires on_write_failure / deactivate and
-                # swaps NotALeader for SessionExpired. assert_success! raises
-                # *outside* RoutedConnection's wrapper, so this is the only place
-                # the classifier sees FAILURE responses to RUN.
-                classified = connection.classify_failure(e)
                 # Server is in FAILED state; RESET so the connection is immediately
                 # reusable — but not if it's being discarded (auth failure: the
                 # server closes it, RESET would just error).

--- a/lib/mri/neo4j/driver/session.rb
+++ b/lib/mri/neo4j/driver/session.rb
@@ -74,45 +74,72 @@ module Neo4j
 
         connection = acquire_connection(session_access_mode)
         fetch_size = effective_fetch_size
-        # The result streams through this buffer, filled by the connection's
-        # reader via the StreamHandler we register for the RUN's PULL.
-        buffer = Bolt::RecordBuffer.new(fetch_size: fetch_size)
-        handler = Bolt::StreamHandler.new(buffer)
+        # TELEMETRY 2 = auto-commit, pipelined ahead of RUN once (not resent on an
+        # idempotent retry) when the server opted in and the driver didn't disable
+        # it; its SUCCESS is read before the RUN reply.
+        telemetry_pending = connection.telemetry(2, disabled: @options[:telemetry_disabled])
+        # Feature:IdempotentRetries — an auto-commit RUN whose failure the server
+        # flags `_idempotent` may be retried once: RESET clears the FAILED state
+        # (and drains the pipelined PULL's IGNORED), then RUN+PULL are re-sent
+        # (TELEMETRY is not). Only the RUN reply is eligible — a telemetry failure
+        # or a later stream (PULL) failure is raised as usual.
+        retries_left = auto_commit_retries_enabled? ? 1 : 0
 
-        run_response =
-          begin
-            # TELEMETRY 2 = auto-commit, pipelined ahead of RUN when the server
-            # opted in and the driver didn't disable it; its SUCCESS is read first.
-            telemetry_sent = connection.telemetry(2, disabled: @options[:telemetry_disabled])
-            # Auto-commit RUN carries this session's NotificationsConfig (5.2+);
-            # the tx path puts it on BEGIN instead. nil / non-5.2 => absent.
-            connection.send_message(connection.protocol.build_run(query, parameters, run_extra,
-                                                                  notification_config: @options[:notification_config]))
-            connection.send_message(connection.protocol.build_pull(n: fetch_size), handler)
-            connection.flush
-            connection.fetch_response.assert_success! if telemetry_sent
-            connection.fetch_response.assert_success!
-          rescue Exceptions::Neo4jException => e
-            # Classify first: this notifies the auth-token manager (and
-            # may flag the connection for discard on an auth failure) and,
-            # for routed connections, fires on_write_failure / deactivate
-            # and swaps NotALeader for SessionExpired. assert_success!
-            # raises *outside* RoutedConnection's wrapper, so this is the
-            # only place the classifier sees FAILURE responses to RUN.
-            classified = connection.classify_failure(e)
-            # Server is in FAILED state; RESET so the connection is
-            # immediately reusable — but not if it's being discarded
-            # (auth failure: the server closes it, RESET would just error).
-            connection.reset! unless connection.auth_failed
-            @connection_provider.release(connection)
-            raise classified
-          rescue StandardError
-            # Transport-level failure (IO/socket) — the connection is
-            # likely dead. Return it to the pool either way so this lease
-            # doesn't leak; the next user will rediscover the breakage.
-            @connection_provider.release(connection)
-            raise
-          end
+        buffer = handler = run_response = nil
+        loop do
+          # A fresh stream per attempt — a prior attempt's buffer saw the IGNORED.
+          buffer = Bolt::RecordBuffer.new(fetch_size: fetch_size)
+          handler = Bolt::StreamHandler.new(buffer)
+          retry_run = false
+          # `stage` tells the rescue which reply raised: only a :run failure is
+          # idempotent-retryable (not :telemetry, nor a send/flush transport error).
+          stage = nil
+          run_response =
+            begin
+              # Auto-commit RUN carries this session's NotificationsConfig (5.2+);
+              # the tx path puts it on BEGIN instead. nil / non-5.2 => absent.
+              connection.send_message(connection.protocol.build_run(query, parameters, run_extra,
+                                                                    notification_config: @options[:notification_config]))
+              connection.send_message(connection.protocol.build_pull(n: fetch_size), handler)
+              connection.flush
+              if telemetry_pending
+                telemetry_pending = false
+                stage = :telemetry
+                connection.fetch_response.assert_success!
+              end
+              stage = :run
+              connection.fetch_response.assert_success!
+            rescue Exceptions::Neo4jException => e
+              if stage == :run && retries_left.positive? && idempotent_error?(e) && !connection.auth_failed
+                retries_left -= 1
+                # RESET clears FAILED and drains the abandoned RUN/PULL replies.
+                connection.reset!
+                retry_run = true
+                nil
+              else
+                # Classify first: this notifies the auth-token manager (and may
+                # flag the connection for discard on an auth failure) and, for
+                # routed connections, fires on_write_failure / deactivate and
+                # swaps NotALeader for SessionExpired. assert_success! raises
+                # *outside* RoutedConnection's wrapper, so this is the only place
+                # the classifier sees FAILURE responses to RUN.
+                classified = connection.classify_failure(e)
+                # Server is in FAILED state; RESET so the connection is immediately
+                # reusable — but not if it's being discarded (auth failure: the
+                # server closes it, RESET would just error).
+                connection.reset! unless connection.auth_failed
+                @connection_provider.release(connection)
+                raise classified
+              end
+            rescue StandardError
+              # Transport-level failure (IO/socket) — the connection is likely
+              # dead. Return it to the pool either way so this lease doesn't leak;
+              # the next user will rediscover the breakage.
+              @connection_provider.release(connection)
+              raise
+            end
+          break unless retry_run
+        end
 
         keys = (run_response.metadata[:fields] || run_response.metadata['fields'] || []).map(&:to_sym)
         @current_result = Result.new(
@@ -317,6 +344,23 @@ module Neo4j
       def effective_fetch_size
         size = @options[:fetch_size]
         size.nil? ? 1000 : size
+      end
+
+      # Feature:IdempotentRetries. A session-level AutoCommitRetriesMode wins;
+      # otherwise fall back to the driver-level `auto_commit_retries_disabled`
+      # default (merged into the session options), which defaults to enabled.
+      def auto_commit_retries_enabled?
+        case @options[:auto_commit_retries_mode]
+        when AutoCommitRetriesMode::ENABLED then true
+        when AutoCommitRetriesMode::DISABLED then false
+        else !@options[:auto_commit_retries_disabled]
+        end
+      end
+
+      # A server FAILURE the server marks retryable via `_idempotent` in its
+      # diagnostic record.
+      def idempotent_error?(error)
+        error.diagnostic_record&.[](:_idempotent) == true
       end
 
       # Default access mode for the session — drives connection routing for

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -109,7 +109,7 @@ module TestkitBackend
 
         # --- Other features --------------------------------------------------
         'Feature:Impersonation'                             => 'jar',
-        'Feature:IdempotentRetries'                         => 'ja',
+        'Feature:IdempotentRetries'                         => 'jar',
 
         # --- Optimizations ---------------------------------------------------
         'Optimization:AuthPipelining'                       => 'ja',


### PR DESCRIPTION
Closes the MRI gap on `Feature:IdempotentRetries` (`ja` → `jar`).

## What

An auto-commit `session.run` whose **RUN reply** is a server FAILURE flagged `_idempotent` in its diagnostic record is retried **once**: `RESET` clears the FAILED state (and drains the pipelined PULL's `IGNORED`), then RUN+PULL are re-sent — **without** re-sending `TELEMETRY`. A second failure (idempotent or not) is raised, as is a non-idempotent first failure.

Scope guards (verified against the stub scripts, which flag `_idempotent` on telemetry/pull failures too):
- A `stage` marker keeps a **TELEMETRY**-reply failure and send/flush transport errors out of the retry path.
- A **PULL**/stream failure surfaces during iteration as before (the RUN already succeeded).
- **Explicit** (`begin_transaction`) and **managed** transactions are unaffected — this is the auto-commit path only.

Config (tri-state, matches Java): session-level `AutoCommitRetriesMode` wins; otherwise the driver-level `auto_commit_retries_disabled` default applies (defaulting to enabled). Both were already plumbed from the testkit-backend and flow via `driver.session`'s option merge — no new wiring.

## Testing

rust boltstub (MRI backend):
- `tests.stub.idempotent_retries` **8/8** — retry-then-success, telemetry-not-resent, two-errors-give-up, error-on-pull/telemetry not retried, the full driver×session config matrix, explicit-tx no-retry
- Regression: `iteration` 56/0, `tx_run` 19/0, `errors` 8/0, `summary` 132/0, `driver_execute_query` 15/0, `disconnects` 12/0; MRI unit specs 69/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-commit queries can now be retried once when the server identifies a failure as safe to retry.
  * Retry behavior is controlled through session or driver settings.

* **Bug Fixes**
  * Prevented retries for telemetry, streaming, pull, and transport failures that are not safe to repeat.
  * Improved connection recovery before retrying eligible queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->