### PR TITLE
feat(mri): optimistic home-database cache [Optimization:HomeDatabaseCache]

### DIFF
--- a/lib/mri/neo4j/driver/auth_tokens.rb
+++ b/lib/mri/neo4j/driver/auth_tokens.rb
@@ -32,7 +32,7 @@ module Neo4j
         def custom(principal, credentials, realm, scheme, parameters = {})
           token = { scheme: scheme, principal: principal, credentials: credentials }
           token[:realm] = realm if realm
-          token[:parameters] = parameters unless parameters.empty?
+          token[:parameters] = parameters unless parameters.nil? || parameters.empty?
           token
         end
       end

--- a/lib/mri/neo4j/driver/bolt/connection.rb
+++ b/lib/mri/neo4j/driver/bolt/connection.rb
@@ -81,6 +81,10 @@ module Neo4j
           # LOGOFF/LOGON replies pipelined ahead of the next operation and not yet
           # consumed (Optimization:AuthPipelining).
           @pending_auth_acks = 0
+          # Guards the one-shot #on_close swap: close (caller thread) and
+          # mark_closed_broken (reader thread) can race, and firing the callback
+          # twice would double-decrement the routing SSR tally.
+          @on_close_mutex = Mutex.new
           @recv_timeout = nil # server's connection.recv_timeout_seconds hint
           @read_deadline = nil # monotonic bound for acquisition-phase reads
           # Writes go behind a mutex: the reader writes watermark follow-up
@@ -111,7 +115,7 @@ module Neo4j
           @auth_epoch = 0
         end
 
-        def connect
+        def connect(deadline: nil)
           last_error = nil
           # One monotonic acquisition deadline for the whole connect, shared by
           # every resolved-address attempt AND the handshake/HELLO reads: a
@@ -120,8 +124,10 @@ module Neo4j
           # gets only the *remaining* budget (open_socket / bounded reads). A
           # total deadline (not a per-read timeout) so interleaved NOOP
           # keepalives can't reset the clock. Cleared once the connection is
-          # ready and steady-state reads use the recv-timeout hint instead.
-          @read_deadline = acquisition_deadline
+          # ready and steady-state reads use the recv-timeout hint instead. A
+          # caller-supplied deadline (home-db optimistic acquire + fallback
+          # sharing one budget) wins over this connection's own.
+          @read_deadline = deadline || acquisition_deadline
           resolved_addresses.each do |host, port|
             begin
               open_socket(host, port)
@@ -189,6 +195,7 @@ module Neo4j
         rescue StandardError
           discard_socket
           @closed = true
+          fire_on_close
           false
         end
 
@@ -232,6 +239,7 @@ module Neo4j
           return if @closed
 
           @closed = true
+          fire_on_close
           # Best-effort GOODBYE before we tear down. Frame+write directly rather
           # than via send_message (which would re-arm the reader) / fetch (GOODBYE
           # has no reply). Then stop the reader and close the socket.
@@ -258,6 +266,23 @@ module Neo4j
         # auth-bleed problem disappear without needing connection-pin
         # bookkeeping.
         attr_reader :auth, :driver_auth
+
+        # Whether the server advertised `ssr.enabled` in its HELLO hints
+        # (Bolt 5.8+ server-side routing). Gates the optimistic home-db cache.
+        def ssr_enabled? = @ssr_enabled == true
+
+        # Fired once, the first time this connection tears down (clean GOODBYE,
+        # broken read, or a failed RESET). The routing provider uses it to keep
+        # its pool-wide SSR tally current. nil for the direct provider.
+        attr_reader :on_close
+
+        # Register the teardown callback. If the connection already tore down
+        # (the reader could break it between build and this assignment), fire it
+        # right away so the SSR tally can't miss this connection's decrement.
+        def on_close=(callback)
+          @on_close_mutex.synchronize { @on_close = callback }
+          fire_on_close if closed?
+        end
 
         # The auth "generation" this connection last authenticated at.
         # The provider bumps its own counter on an AuthorizationExpired
@@ -791,6 +816,21 @@ module Neo4j
         def mark_closed_broken
           @socket&.close rescue nil
           @closed = true
+          fire_on_close
+        end
+
+        # Invoke the teardown callback exactly once (nilled after firing, so the
+        # several @closed transitions can each call it safely).
+        def fire_on_close
+          # Atomically claim the callback so concurrent teardown paths (close vs
+          # the reader's mark_closed_broken) fire it exactly once; call outside
+          # the lock — the callback re-enters the load balancer's SSR mutex.
+          callback = @on_close_mutex.synchronize do
+            cb = @on_close
+            @on_close = nil
+            cb
+          end
+          callback&.call(self)
         end
 
         # The timeout the next read may take. During acquisition (handshake,
@@ -995,6 +1035,10 @@ module Neo4j
           # `telemetry.enabled` hint (Bolt 5.4+) opts the server into receiving
           # TELEMETRY reports; without it the driver stays silent.
           @telemetry_enabled = hello.metadata.dig(:hints, :'telemetry.enabled') == true
+          # `ssr.enabled` hint (Bolt 5.8+) means this server does server-side
+          # routing, so the driver may guess a home database optimistically (the
+          # server re-routes if the guess is wrong) — see the home-db cache.
+          @ssr_enabled = hello.metadata.dig(:hints, :'ssr.enabled') == true
 
           fetch_response.assert_success! if logon_msg
         end

--- a/lib/mri/neo4j/driver/bolt/pool.rb
+++ b/lib/mri/neo4j/driver/bolt/pool.rb
@@ -46,6 +46,10 @@ module Neo4j
           # instead of connecting as the manager and re-authing.
           @connect_factory = connect_factory
           @auth_key = :"bolt_pool_next_auth_#{object_id}"
+          # Companion thread-local (same pattern as @auth_key) carrying the
+          # acquisition deadline a freshly-built connection's handshake must
+          # honour — so one budget spans the home-db guess + fallback.
+          @deadline_key = :"bolt_pool_next_deadline_#{object_id}"
           # Metrics counters (driver.metrics / testkit GetConnectionPoolMetrics):
           # @created = live connections this pool has built (idle + in use),
           # @leased = currently checked out. idle = created - leased. Guarded by
@@ -56,7 +60,7 @@ module Neo4j
           @created = 0
           @leased = 0
           @stack = ConnectionPool::TimedStack.new(size: size) do
-            @connect_factory.call(Thread.current[@auth_key]).tap { bump(created: 1) }
+            @connect_factory.call(Thread.current[@auth_key], Thread.current[@deadline_key]).tap { bump(created: 1) }
           end
         end
 
@@ -71,13 +75,17 @@ module Neo4j
         # Loops until a usable one is found or the acquisition-timeout
         # budget runs out — every discarded slot opens room for the
         # factory to make a fresh one.
-        def pop(auth: nil)
+        def pop(auth: nil, deadline: nil)
           # The token a freshly-built connection should authenticate with,
           # handed to the create block via a thread-local that lives only
           # for this pop (see #initialize). Cleared in `ensure` so it never
           # leaks into a later create on the same thread.
           Thread.current[@auth_key] = auth
-          deadline = current_monotonic + acquisition_timeout
+          # A caller-supplied deadline lets one acquisition-timeout budget span
+          # several pops (the home-db optimistic acquire + its fallback), and
+          # bounds a freshly-built connection's handshake via the create block.
+          deadline ||= current_monotonic + acquisition_timeout
+          Thread.current[@deadline_key] = deadline
           loop do
             timeout = [deadline - current_monotonic, 0].max
             conn = @stack.pop(timeout: timeout)
@@ -92,6 +100,7 @@ module Neo4j
                 "Unable to acquire connection from the pool within configured maximum time of #{format_acquisition_timeout}"
         ensure
           Thread.current[@auth_key] = nil
+          Thread.current[@deadline_key] = nil
         end
 
         def push(connection)

--- a/lib/mri/neo4j/driver/direct/connection_provider.rb
+++ b/lib/mri/neo4j/driver/direct/connection_provider.rb
@@ -41,6 +41,12 @@ module Neo4j
         # unset (matches Java's DirectConnectionProvider).
         def home_database(_bookmarks, _imp_user = nil, _auth = nil) = nil
 
+        # No home-db cache on the direct path (one server, no discovery to skip):
+        # never guess, never track SSR. Keeps Session polymorphic across providers.
+        def ssr_enabled? = false
+        def home_db_guess(_imp_user, _auth) = nil
+        def cache_home_db(_imp_user, _auth, _database) = nil
+
         # The current default identity, sourced from the auth-token
         # manager (which refreshes / re-fetches as needed). Sessions
         # re-auth pooled connections to this on acquire unless they carry
@@ -68,7 +74,7 @@ module Neo4j
         # Routing::LoadBalancer#acquire but unused here: the direct path
         # has no discovery, so impersonation is enforced on RUN/BEGIN by
         # the protocol handler (Bolt::Protocol::Base#enforce_impersonation_support!).
-        def acquire(access_mode: nil, database: nil, bookmarks: nil, imp_user: nil, auth: nil)
+        def acquire(access_mode: nil, database: nil, bookmarks: nil, imp_user: nil, auth: nil, deadline: nil)
           # See Routing::LoadBalancer#acquire for the rationale.
           raise Exceptions::IllegalStateException, 'Driver is closed' if @closed
 
@@ -92,7 +98,7 @@ module Neo4j
             # connection's stamp (in ensure_identity) use one consistent value.
             epoch = auth_epoch
             effective = auth || @auth_manager.get_token
-            conn = pool.pop(auth: effective)
+            conn = pool.pop(auth: effective, deadline: deadline)
             begin
               ensure_identity(conn, effective, session_auth: auth, epoch: epoch)
             rescue StandardError
@@ -228,12 +234,12 @@ module Neo4j
             size: max_pool_size,
             options: @options,
             clock: @clock,
-            connect_factory: lambda { |auth|
+            connect_factory: lambda { |auth, deadline = nil|
               # `auth` is the per-acquire identity resolved in #acquire and
               # threaded through pool.pop. The `||` is a belt-and-braces
               # fallback for any future pop path that forgets to pass one.
               conn = Bolt::Connection.new(@uri, auth || @auth_manager.get_token, @options,
-                                          domain_name_resolver: @domain_name_resolver, clock: @clock).connect
+                                          domain_name_resolver: @domain_name_resolver, clock: @clock).connect(deadline: deadline)
               conn.security_exception_handler = method(:on_security_exception)
               # A freshly-authenticated connection belongs to the current
               # auth generation, so ensure_identity won't force-re-auth it.

--- a/lib/mri/neo4j/driver/internal/home_db_cache.rb
+++ b/lib/mri/neo4j/driver/internal/home_db_cache.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Driver
+    module Internal
+      # Driver-level cache mapping a user identity to their most recently
+      # resolved home database (Optimization:HomeDatabaseCache). It lets a routed
+      # session skip home-database discovery by optimistically guessing the
+      # cached database — safe only when every pooled connection advertised
+      # server-side routing (`ssr.enabled`), so the server transparently
+      # re-routes a wrong guess. Bounded, least-recently-used eviction.
+      class HomeDbCache
+        DEFAULT_MAX_SIZE = 10_000
+
+        def initialize(max_size: DEFAULT_MAX_SIZE)
+          @max_size = max_size
+          # Insertion order doubles as LRU recency: a Ruby Hash preserves it, so
+          # #get re-inserts the touched key at the end and #set evicts from the
+          # front once the cache is full.
+          @entries = {}
+          @mutex = Mutex.new
+        end
+
+        # The cache key for an identity: the impersonated user when set, else the
+        # per-session auth token (driver-level auth is nil, so every default-auth
+        # session shares one entry — the cache is bound to the identity, not the
+        # rotating token). Matches the Java driver: a basic-auth principal is NOT
+        # folded into the impersonated-user space
+        # (Optimization:HomeDbCacheBasicPrincipalIsImpersonatedUser stays off).
+        def compute_key(imp_user, auth) = imp_user || auth
+
+        # The cached database for this key, or nil on a miss. Touches recency.
+        def get(key)
+          @mutex.synchronize do
+            next nil unless @entries.key?(key)
+
+            database = @entries.delete(key)
+            @entries[key] = database
+            database
+          end
+        end
+
+        # Remember (or refresh) the resolved home database for this key. A nil
+        # database is ignored — there's nothing to guess next time.
+        def set(key, database)
+          return if database.nil?
+
+          @mutex.synchronize do
+            @entries.delete(key)
+            @entries[key] = database
+            @entries.shift while @entries.size > @max_size
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mri/neo4j/driver/routing/load_balancer.rb
+++ b/lib/mri/neo4j/driver/routing/load_balancer.rb
@@ -54,6 +54,35 @@ module Neo4j
           # Monitor (reentrant) because ensure_routing_table_is_fresh holds
           # the lock while it goes through pool_for, which also locks.
           @refresh_lock = Monitor.new
+          # Optimization:HomeDatabaseCache — a driver-wide identity->home-db
+          # cache, consulted only when every open pooled connection advertises
+          # server-side routing (@ssr_with/@ssr_without track that tally, kept
+          # current by track_ssr_open/close as connections open and tear down).
+          @home_db_cache = Internal::HomeDbCache.new
+          @ssr_with = 0
+          @ssr_without = 0
+          @ssr_lock = Mutex.new
+        end
+
+        attr_reader :home_db_cache
+
+        # Home-db cache gate: true when there is at least one open pooled
+        # connection and every one advertised `ssr.enabled`, so the server will
+        # re-route an optimistically guessed home database.
+        def ssr_enabled? = @ssr_lock.synchronize { @ssr_with.positive? && @ssr_without.zero? }
+
+        def track_ssr_open(conn)
+          @ssr_lock.synchronize { conn.ssr_enabled? ? @ssr_with += 1 : @ssr_without += 1 }
+        end
+
+        def track_ssr_close(conn)
+          @ssr_lock.synchronize do
+            if conn.ssr_enabled?
+              @ssr_with -= 1 if @ssr_with.positive?
+            else
+              @ssr_without -= 1 if @ssr_without.positive?
+            end
+          end
         end
 
         # Open (or pop) a connection appropriate for `access_mode` against
@@ -61,7 +90,7 @@ module Neo4j
         # acquire, deactivate on connection failure and try again. Raises
         # ServiceUnavailableException only when the role bucket has been
         # exhausted by deactivations.
-        def acquire(access_mode: :write, database: nil, bookmarks: nil, imp_user: nil, auth: nil)
+        def acquire(access_mode: :write, database: nil, bookmarks: nil, imp_user: nil, auth: nil, deadline: nil)
           # Fast-fail with IllegalStateException for use-after-close.
           # Otherwise the next routing fetch would propagate a generic
           # Connection-refused ServiceUnavailableException, masking the
@@ -115,7 +144,7 @@ module Neo4j
               # Re-resolve per turn (see acquire header): a discard-and-retry
               # on Bolt 5.0 token rotation must issue its own get_token.
               effective = auth || @auth_manager.get_token
-              inner = pool.pop(auth: effective)
+              inner = pool.pop(auth: effective, deadline: deadline)
               begin
                 ensure_identity(inner, effective, session_auth: auth, address: address, epoch: epoch)
               rescue StandardError
@@ -164,7 +193,39 @@ module Neo4j
           # routing driver surfaced the wrong error type.
           raise Exceptions::IllegalStateException, 'Driver is closed' if @closed
 
-          ensure_routing_table_is_fresh(nil, :read, bookmarks: bookmarks, imp_user: imp_user, auth: auth).database
+          resolved = ensure_routing_table_is_fresh(nil, :read, bookmarks: bookmarks, imp_user: imp_user, auth: auth).database
+          # Remember the authoritative name (Optimization:HomeDatabaseCache) so a
+          # later same-identity session can guess it and skip discovery.
+          cache_home_db(imp_user, auth, resolved)
+          resolved
+        end
+
+        # Optimization:HomeDatabaseCache — this identity's last resolved home
+        # database, or nil when we can't optimistically guess it: no cache entry,
+        # or not every open connection does server-side routing (so the server
+        # might not re-route a stale guess). Used only to pick the routing table
+        # to acquire against — the operation still sends db=null so the server
+        # resolves the real home db.
+        def home_db_guess(imp_user, auth)
+          return nil unless ssr_enabled?
+
+          @home_db_cache.get(@home_db_cache.compute_key(imp_user, auth))
+        end
+
+        # Record the server's resolved home database for this identity.
+        def cache_home_db(imp_user, auth, database)
+          @home_db_cache.set(@home_db_cache.compute_key(imp_user, auth), database)
+        end
+
+        # Whether a usable table for `database` is already cached — so acquiring
+        # against it won't ROUTE. The home-db cache uses this to decide whether a
+        # guessed db can be sent as db=nil (table fresh, server resolves) or must
+        # be pinned (a ROUTE will run and authoritatively resolve it).
+        def routing_table_fresh?(database, access_mode = :read)
+          @refresh_lock.synchronize do
+            table = @routing_tables[database]
+            !!table&.fresh?(readonly: access_mode == :read)
+          end
         end
 
         def current_auth_token = @auth_manager.get_token
@@ -550,12 +611,12 @@ module Neo4j
               size: max_pool_size,
               options: @options,
               clock: @clock,
-              connect_factory: ->(auth) { open_connection(address, auth) }
+              connect_factory: ->(auth, deadline = nil) { open_connection(address, auth, deadline) }
             )
           end
         end
 
-        def open_connection(address, auth = nil)
+        def open_connection(address, auth = nil, deadline = nil)
           # Preserve the encryption suffix: neo4j+s → bolt+s,
           # neo4j+ssc → bolt+ssc, neo4j → bolt. Otherwise routing
           # connections to a TLS cluster would open plaintext and the
@@ -570,7 +631,7 @@ module Neo4j
           # worker's resolved token). Fall back to the manager's current
           # token for acquires that don't carry one (verify_connectivity).
           conn = Bolt::Connection.new(uri, auth || @auth_manager.get_token, opts,
-                                      domain_name_resolver: @domain_name_resolver, clock: @clock).connect
+                                      domain_name_resolver: @domain_name_resolver, clock: @clock).connect(deadline: deadline)
           # Bind the security handler to this connection's server so an
           # AuthorizationExpired bumps the right per-address epoch.
           conn.security_exception_handler =
@@ -578,6 +639,10 @@ module Neo4j
           # A freshly-authenticated connection belongs to the current auth
           # generation for its server, so ensure_identity won't force-re-auth it.
           conn.auth_epoch = auth_epoch_for(address)
+          # Fold this connection into the pool-wide SSR tally (and out of it when
+          # it tears down) so the home-db cache gate reflects live connections.
+          track_ssr_open(conn)
+          conn.on_close = method(:track_ssr_close)
           conn
         end
 

--- a/lib/mri/neo4j/driver/routing/routed_connection.rb
+++ b/lib/mri/neo4j/driver/routing/routed_connection.rb
@@ -53,7 +53,7 @@ module Neo4j
                        :fetch_response, :fetch_all,
                        :reset!, :route,
                        :auth, :driver_auth, :authenticate,
-                       :auth_failed, :notify_security_exception
+                       :auth_failed, :notify_security_exception, :ssr_enabled?
 
         # Run a caught exception through the routing classifier:
         # - ServiceUnavailableException → deactivate(address); mark

--- a/lib/mri/neo4j/driver/session.rb
+++ b/lib/mri/neo4j/driver/session.rb
@@ -18,6 +18,10 @@ module Neo4j
         @open = true
         @last_bookmarks = Set.new
         @current_result = nil
+        # The home database this session pinned after its first resolution
+        # (Optimization:HomeDatabaseCache); nil until then / for explicit-db sessions.
+        @pinned_database = nil
+        @used_guess = false  # whether an operation optimistically guessed the home db
         @bookmark_manager = options[:bookmark_manager]
         # The bookmark snapshot we sent on the most recent BEGIN — used
         # as `previous_bookmarks` when forwarding to the manager so it
@@ -62,8 +66,13 @@ module Neo4j
         # the named user had issued it — auth as the session's user,
         # authz as the impersonated one.
         bookmarks = current_bookmarks_for_extra
+        # Acquire (with its own bookmark snapshot) so the home-db cache can pick
+        # the routing table: on a cache guess the RUN sends db=nil (server
+        # re-resolves), otherwise it pins the discovered name. run_db carries
+        # whichever applies; run_extra keeps this operation's bookmark snapshot.
+        connection, run_db = acquire_for_operation(session_access_mode)
         run_extra = {
-          db: operation_database(bookmarks),
+          db: run_db,
           mode: (session_access_mode == :read ? 'r' : nil),
           tx_timeout: timeout_to_milliseconds(timeout),
           tx_metadata:,
@@ -72,7 +81,6 @@ module Neo4j
         }
         run_extra.reject!(&Internal::Extras::BLANK)
 
-        connection = acquire_connection(session_access_mode)
         fetch_size = effective_fetch_size
         # Feature:IdempotentRetries — an auto-commit RUN whose failure the server
         # flags `_idempotent` may be retried once: RESET clears the FAILED state
@@ -144,6 +152,10 @@ module Neo4j
             end
           break unless retry_run
         end
+
+        # A home-db RUN that sent db=nil comes back with the server's resolved
+        # home database — cache it so the next same-identity session can guess.
+        cache_home_db_from(run_response)
 
         keys = (run_response.metadata[:fields] || run_response.metadata['fields'] || []).map(&:to_sym)
         @current_result = Result.new(
@@ -272,56 +284,81 @@ module Neo4j
       # `bookmarks` is the snapshot the caller is already using for this
       # operation's wire `bookmarks` — passed in (not recomputed) so a single
       # operation never takes two different BookmarkManager snapshots.
-      def operation_database(bookmarks)
-        return @options[:database] if @options[:database]
-        return @home_database if defined?(@home_database)
-
-        # Resolution goes through discovery, so it must carry the same
-        # identity/impersonation context as the operation's own acquire —
-        # otherwise a per-session token or a pre-4.4 impersonation attempt
-        # would be evaluated under the wrong identity (session-auth routing)
-        # or surface as a discovery ServiceUnavailable instead of the
-        # ClientException the caller expects.
-        @home_database = @connection_provider.home_database(
-          bookmarks, @options[:impersonated_user], @options[:auth_token]
-        )
-      end
-
-      def acquire_connection(access_mode)
-        # The identity is resolved and applied by the connection provider
-        # (it owns the pool, so it knows whether a popped connection is fresh
-        # — built with the right token already — or a reused one that must be
-        # re-authed). We only hand it the per-session override: a non-nil
-        # `:auth_token` pins this session to that identity (matches Java's
-        # SessionConfig.withAuthToken so the JRuby ConfigConverter delegates
-        # via with_auth_token without special-casing). nil means "use the
-        # auth-token manager's current token", and the provider consults the
-        # manager exactly as many times as the path needs (once for direct,
-        # once for discovery + once for the worker on routing) — never an
-        # extra time for a redundant re-auth.
-        # Snapshot the bookmarks once: current_bookmarks_for_extra consults the
-        # BookmarkManager and records @bookmarks_used_on_begin, so a second call
-        # could take a different snapshot — home-db discovery must route with the
-        # same bookmarks the acquire threads on the wire.
+      # Acquire the operation's connection and decide the db it should send
+      # (Optimization:HomeDatabaseCache). Returns [connection, run_db]:
+      #   - explicit :database  -> acquire against it, send it.
+      #   - home-db + cache guess (SSR pool) -> acquire against the guessed home
+      #     db (reuses its routing table, no discovery) but send db=nil so the
+      #     server re-resolves; unless the acquired connection turns out non-SSR
+      #     (a mixed cluster can't re-route), in which case fall back to explicit
+      #     discovery and pin the resolved name.
+      #   - home-db, no guess -> discover, pin, send the resolved name.
+      def acquire_for_operation(access_mode)
+        # Its own bookmark snapshot for discovery/acquire — distinct from the
+        # RUN/BEGIN extra's snapshot, so a BookmarkManager supplier is consulted
+        # once per acquire (matching the reference drivers / the bookmark-manager
+        # tests), and home-db discovery routes with a fresh set.
         bookmarks = current_bookmarks_for_extra
-        @connection_provider.acquire(
-          access_mode: access_mode,
-          # Hand the provider the resolved database: for a home-db session
-          # (nil :database on a routing driver) operation_database runs
-          # discovery once and memoizes the resolved name, so the acquire
-          # reuses the table already cached under that name instead of
-          # re-routing. Explicit :database and the direct provider pass through
-          # unchanged (nil stays nil).
-          database: operation_database(bookmarks),
-          bookmarks: bookmarks,
-          # Threaded into routing discovery so the ROUTE call enforces
-          # impersonation support (Bolt 4.4+) before sending; the direct
-          # provider ignores it (RUN/BEGIN enforce it instead).
-          imp_user: @options[:impersonated_user],
-          auth: @options[:auth_token]
-        )
+        explicit = @options[:database]
+        return [do_acquire(access_mode, explicit, bookmarks), explicit] if explicit
+        # Once this session has resolved its home db, pin it for the rest of the
+        # session — later runs send it explicitly so a re-resolving server can't
+        # move the session to a different database mid-flight.
+        return [do_acquire(access_mode, @pinned_database, bookmarks), @pinned_database] if @pinned_database
+
+        imp_user = @options[:impersonated_user]
+        auth = @options[:auth_token]
+        # Guess only pays off when we already hold a fresh routing table for it:
+        # acquire against that table and send db=nil so the server resolves the
+        # real home db. If its table is stale (or the connection turns out
+        # non-SSR), fall through to explicit discovery — a ROUTE with db=nil that
+        # authoritatively resolves and pins the home db. The optimistic acquire
+        # and the fallback share one acquisition-timeout deadline.
+        guess = @connection_provider.home_db_guess(imp_user, auth)
+        if guess && @connection_provider.routing_table_fresh?(guess, access_mode)
+          deadline = acquisition_deadline
+          connection = do_acquire(access_mode, guess, bookmarks, deadline)
+          if connection.ssr_enabled?
+            # A real guess: the reply's db will pin the session (cache_home_db_from).
+            @used_guess = true
+            return [connection, nil]
+          end
+
+          @connection_provider.release(connection)
+          resolved = @connection_provider.home_database(bookmarks, imp_user, auth)
+          @pinned_database = resolved
+          return [do_acquire(access_mode, resolved, bookmarks, deadline), resolved]
+        end
+        resolved = @connection_provider.home_database(bookmarks, imp_user, auth)
+        @pinned_database = resolved
+        [do_acquire(access_mode, resolved, bookmarks), resolved]
       end
 
+      def do_acquire(access_mode, database, bookmarks, deadline = nil)
+        @connection_provider.acquire(access_mode: access_mode, database: database, bookmarks: bookmarks,
+                                     imp_user: @options[:impersonated_user], auth: @options[:auth_token],
+                                     deadline: deadline)
+      end
+
+      # A single acquisition-timeout deadline (monotonic seconds) so a guessed
+      # acquire and its fallback share one budget, matching the reference drivers.
+      def acquisition_deadline
+        @clock.monotonic + (@options[:connection_acquisition_timeout]&.to_f || 60)
+      end
+
+      # Record the server's resolved home database from a RUN/BEGIN reply, so a
+      # later same-identity session guesses it. No-op for explicit-db sessions
+      # (their reply omits db) and the direct provider (cache_home_db is a no-op).
+      def cache_home_db_from(response)
+        db = response.metadata[:db]
+        return if db.nil? || @options[:database]
+
+        # First guess-based run learns the real home db from the reply — pin it
+        # for the session (only when we actually guessed; direct drivers never
+        # pin) and remember it for the driver-wide cache.
+        @pinned_database ||= db if @used_guess
+        @connection_provider.cache_home_db(@options[:impersonated_user], @options[:auth_token], db)
+      end
 
       # Current bookmark snapshot as a plain array of strings, ready
       # for the wire. Returns nil when empty so the BEGIN/RUN extras
@@ -515,27 +552,22 @@ module Neo4j
       end
 
       def open_transaction(op_mode, tx_options, telemetry_api:, telemetry_ack: nil)
-        # Acquire first: acquire_connection drives routing discovery (which
-        # resolves the home database), so by the time we read the BEGIN
-        # snapshot below the routing table is fresh and operation_database
-        # needs no extra round-trip.
-        connection = acquire_connection(op_mode)
-        # Take the BEGIN bookmark snapshot once — after acquire so it reflects
-        # the latest BookmarkManager state — and reuse it for the home-db
-        # resolution, so a single transaction never takes two different
-        # snapshots. current_bookmarks_for_extra also records
-        # @bookmarks_used_on_begin so the commit-time update_bookmarks reports
-        # the right `previous` set.
+        # Acquire and decide the BEGIN db together (Optimization:HomeDatabaseCache):
+        # a cache guess picks the routing table and sends db=nil; otherwise the
+        # discovered/pinned name is sent. It takes its own bookmark snapshot for
+        # discovery. begin_db is dropped when nil via compact.
+        connection, begin_db = acquire_for_operation(op_mode)
+        # The BEGIN's own snapshot, taken last so current_bookmarks_for_extra
+        # records @bookmarks_used_on_begin as the set actually sent on BEGIN (the
+        # commit-time update_bookmarks reports it as `previous`).
         bookmarks = current_bookmarks_for_extra
-        # Resolved home database (nil = let the server resolve it), so the
-        # explicit/managed-tx BEGIN carries the same `db` as the auto-commit
-        # path. Dropped when nil via compact.
-        tx_options = tx_options.merge(database: operation_database(bookmarks)).compact
+        tx_options = tx_options.merge(database: begin_db).compact
         Transaction.new(connection, self, bookmarks, tx_options, telemetry_api: telemetry_api,
                         telemetry_ack: telemetry_ack,
                         # executeQuery's session reports telemetry api 3 (DRIVER_EXECUTE_QUERY);
                         # only that path pipelines BEGIN + RUN + PULL (Optimization:ExecuteQueryPipelining).
                         pipelined: @options[:telemetry_api] == 3,
+                        on_begin: method(:cache_home_db_from),
                         on_release: -> { @connection_provider.release(connection) })
       end
     end

--- a/lib/mri/neo4j/driver/transaction.rb
+++ b/lib/mri/neo4j/driver/transaction.rb
@@ -7,13 +7,14 @@ module Neo4j
       attr_reader :connection
 
       def initialize(connection, session, bookmarks = [], options = {}, telemetry_api: nil, telemetry_ack: nil,
-                     pipelined: false, on_release: nil)
+                     pipelined: false, on_begin: nil, on_release: nil)
         @connection = connection
         @session = session
         @options = options
         # executeQuery pipelines BEGIN + RUN + PULL (Optimization:ExecuteQueryPipelining):
         # BEGIN's reply is read only after the first RUN+PULL are flushed, not eagerly.
         @pipelined = pipelined
+        @on_begin = on_begin      # called with the BEGIN reply (home-db cache update)
         @on_release = on_release  # called once when the connection is no longer needed
         @open = true
         @committed = false
@@ -269,7 +270,10 @@ module Neo4j
           # The server acknowledged telemetry; a managed-tx retry won't re-send it.
           @telemetry_ack&.call
         end
-        @connection.fetch_response.assert_success!
+        begin_response = @connection.fetch_response.assert_success!
+        # A home-db BEGIN that sent db=nil comes back with the resolved name.
+        @on_begin&.call(begin_response)
+        begin_response
       end
 
       # The transaction is terminated once a server failure has hit it — either

--- a/spec/mri/neo4j/driver/bolt/pool_spec.rb
+++ b/spec/mri/neo4j/driver/bolt/pool_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Neo4j::Driver::Bolt::Pool do
     described_class.new(
       size: 8,
       options: options,
-      connect_factory: ->(_auth) { queue.shift || raise('factory exhausted') }
+      connect_factory: ->(_auth, _deadline = nil) { queue.shift || raise('factory exhausted') }
     )
   end
 
@@ -146,7 +146,7 @@ RSpec.describe Neo4j::Driver::Bolt::Pool do
       pool = described_class.new(
         size: 1,
         options: { connection_acquisition_timeout: 0.05 },
-        connect_factory: ->(_auth) { connection_class.new.tap { |c| c.created_at = monotonic } }
+        connect_factory: ->(_auth, _deadline = nil) { connection_class.new.tap { |c| c.created_at = monotonic } }
       )
       pool.pop # exhaust the single slot
 
@@ -169,7 +169,7 @@ RSpec.describe Neo4j::Driver::Bolt::Pool do
       pool = described_class.new(
         size: 1,
         options: { connection_acquisition_timeout: 0.5 },
-        connect_factory: ->(_auth) { sequence.next }
+        connect_factory: ->(_auth, _deadline = nil) { sequence.next }
       )
       pool.pop # `bad` is now the checked-out one
       pool.discard(bad)
@@ -237,7 +237,7 @@ RSpec.describe Neo4j::Driver::Bolt::Pool do
       pool = described_class.new(
         size: 2,
         options: { connection_liveness_check_timeout: 0.001 },
-        connect_factory: ->(_auth) { sequence.next }
+        connect_factory: ->(_auth, _deadline = nil) { sequence.next }
       )
       pool.pop                     # factory builds `dead` (fresh, no probe) -> in use
       pool.push(dead)              # back to the pool, idle

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -116,7 +116,7 @@ module TestkitBackend
         'Optimization:ConnectionReuse'                      => '',  # disabled in Java too
         'Optimization:EagerTransactionBegin'                => 'jar',
         'Optimization:ExecuteQueryPipelining'               => 'jar',
-        'Optimization:HomeDatabaseCache'                    => 'ja',
+        'Optimization:HomeDatabaseCache'                    => 'jar',
         'Optimization:HomeDbCacheBasicPrincipalIsImpersonatedUser'  => '',
         'Optimization:ImplicitDefaultArguments'             => 'ja',
         'Optimization:MinimalBookmarksSet'                  => '',


### PR DESCRIPTION
Closes the MRI gap on `Optimization:HomeDatabaseCache` (`ja` → `jar`).

## What

A routed driver can skip home-database discovery by reusing an identity's most recently resolved home db — safe only when **every open connection advertises server-side routing** (Bolt 5.8 `ssr.enabled`), so the server transparently re-routes a wrong guess. Mirrors the Java/Python drivers.

## How

- **SSR detection & gating**: `Connection#ssr_enabled?` parses the `ssr.enabled` HELLO hint; a single `#on_close` fires across all teardown paths. `LoadBalancer` maintains a pool-wide SSR tally (`track_ssr_open/close`) and only consults the cache when all open connections are SSR.
- **`Internal::HomeDbCache`**: bounded (10k) LRU keyed by `imp_user`, else the per-session auth token (driver-level auth → one shared key). Matches Java — a basic principal is **not** folded into `imp_user`, so `HomeDbCacheBasicPrincipalIsImpersonatedUser` stays unadvertised (its test correctly skips).
- **Resolution semantics** (`Session#acquire_for_operation`) — the subtle part, verified against the stub scripts:
  - A guess is used **only when its routing table is already fresh** → acquire against it and send `db=null` so the server resolves the real home db (cache updates from the reply's `db`).
  - A **stale** guess or a **non-SSR** connection (mixed cluster) → fall back to discovery (`ROUTE db=null`) and **pin** the resolved name.
  - The session pins its home db after first resolution so a re-resolving server can't move it mid-session; **direct drivers never pin**.
- **Shared acquisition deadline**: the optimistic acquire and its fallback share one budget, threaded `provider#acquire → Pool#pop → Connection#connect` (bounding the handshake too).
- Wired for **session.run**, **explicit/managed tx** (`Transaction#on_begin`), and **executeQuery**. `AuthTokens.custom` now tolerates nil `parameters` (a backend-glue crash the un-skipped tests exposed).

## Testing

rust boltstub (MRI backend): **`tests.stub.homedb` 37/37** — `TestHomeDbWithCache`/`Tx`/`ExecuteQuery` + mixed-cluster fallback (incl. `acquisition_timeout_during_fallback`); 3 sub-feature skips.
No regressions: `tx_run`, `iteration`, `disconnects`, `errors`, `summary`, `driver_execute_query`, `idempotent_retries`, `optimizations`, `configuration_hints`, routing (pool-size/liveness); MRI unit specs 69/0. (The one routing `router_ip_changes` error is the known link-local-IPv6 local flake.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved home database selection with driver-level LRU caching, per-session home database pinning, and cache learning.
  * Added optional connection acquisition deadlines end-to-end (including routing/pool/direct providers).
  * Added SSR capability detection and tracking for pooled routing connections; SSR is explicitly disabled for direct connections.
* **Bug Fixes**
  * Improved authentication token parameter handling to avoid assigning nil/empty parameters.
  * Improved transaction BEGIN callback delivery.
  * Enhanced connection teardown to invoke the close callback exactly once.
* **Tests / Chores**
  * Updated feature-tag advertisement for the home database cache optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->