### PR TITLE
feat(mri): pipeline re-auth LOGOFF+LOGON [Optimization:AuthPipelining]

### DIFF
--- a/lib/mri/neo4j/driver/bolt/connection.rb
+++ b/lib/mri/neo4j/driver/bolt/connection.rb
@@ -78,6 +78,9 @@ module Neo4j
           # pops, both colorless (yields under a Fiber scheduler).
           @inbox = Thread::Queue.new
           @collector = ResponseCollector.new(@inbox)
+          # LOGOFF/LOGON replies pipelined ahead of the next operation and not yet
+          # consumed (Optimization:AuthPipelining).
+          @pending_auth_acks = 0
           @recv_timeout = nil # server's connection.recv_timeout_seconds hint
           @read_deadline = nil # monotonic bound for acquisition-phase reads
           # Writes go behind a mutex: the reader writes watermark follow-up
@@ -271,7 +274,7 @@ module Neo4j
         # connection already holds the target identity — unless `force`
         # (an AuthorizationExpired-driven refresh re-auths to the *same*
         # token to refresh the server's authorization cache).
-        def authenticate(new_auth, force: false)
+        def authenticate(new_auth, force: false, pipelined: true)
           return if !force && @auth == new_auth
           unless @protocol&.supports_re_auth?
             raise Exceptions::UnsupportedFeatureException,
@@ -280,10 +283,25 @@ module Neo4j
 
           send_message(Message.logoff)
           send_message(Message.logon(new_auth || {}))
-          flush
-          fetch_response.assert_success!
-          fetch_response.assert_success!
           @auth = new_auth
+          # AuthPipelining: enqueue LOGOFF + LOGON but don't flush or read their
+          # replies — they ride out with the next operation's messages and are
+          # consumed (via #drain_pending_auth_acks, from the next #fetch_response)
+          # just before that operation reads its own reply, saving a round-trip.
+          # A rejected LOGON surfaces there as the auth failure (the operation's
+          # own message is IGNORED). @auth is set optimistically; a failed re-auth
+          # discards the connection, so a stale value never gets reused.
+          #
+          # pipelined: false forces the synchronous round-trip — verify_authentication
+          # re-auths then discards the connection with no operation to carry (and
+          # drain) the replies, and must see the LOGON's success/failure itself.
+          if pipelined
+            @pending_auth_acks += 2
+          else
+            flush
+            fetch_response.assert_success!
+            fetch_response.assert_success!
+          end
         end
 
         # True when the connection's current identity came from a per-session
@@ -550,13 +568,33 @@ module Neo4j
         # records @broken_error, so a blocked pop wakes with nil and re-raises the
         # classified error rather than hanging.
         def fetch_response
-          # Acquisition phase (no reader yet): drive the reads ourselves. Steady
-          # state: the reader fills @inbox; block on pop until it delivers.
+          # A pipelined re-auth's LOGOFF/LOGON replies sit ahead of this
+          # operation's own reply — consume them first (AuthPipelining).
+          drain_pending_auth_acks
+          pop_inbox
+        end
+
+        # Pop the next sync reply. Acquisition phase (no reader yet): drive the
+        # reads ourselves. Steady state: the reader fills @inbox; block on pop
+        # until it delivers. On a connection failure the reader closes @inbox and
+        # records @broken_error, so a blocked pop wakes with nil and re-raises.
+        def pop_inbox
           advance while @reader.nil? && @inbox.empty?
           message = @inbox.pop
           raise @broken_error if message.nil? && @broken_error
 
           message
+        end
+
+        # Consume the replies to a pipelined re-auth's LOGOFF + LOGON before the
+        # next operation reads its own reply. A rejected LOGON raises the auth
+        # failure here (its follow-on messages come back IGNORED).
+        def drain_pending_auth_acks
+          return if @pending_auth_acks.zero?
+
+          pending = @pending_auth_acks
+          @pending_auth_acks = 0
+          pending.times { pop_inbox.assert_success! }
         end
 
         def fetch_all
@@ -584,6 +622,9 @@ module Neo4j
           # probe, so a failure must surface (and the dead connection be
           # discarded) rather than report false success.
           raise if propagate
+        ensure
+          # RESET flushed and drained any pipelined re-auth replies with it.
+          @pending_auth_acks = 0
         end
 
         # True while the caller still owes a fetch: a request whose terminal the

--- a/lib/mri/neo4j/driver/driver.rb
+++ b/lib/mri/neo4j/driver/driver.rb
@@ -227,8 +227,10 @@ module Neo4j
           # verification has to actually round-trip the credentials to the
           # server, not trust a cached auth state. On a freshly built
           # connection this is a redundant re-auth the scripts tolerate; on a
-          # reused one it's the whole point.
-          connection.authenticate(auth_token, force: true)
+          # reused one it's the whole point. Synchronous (pipelined: false): verify
+          # discards the connection with no operation to carry and drain the
+          # LOGOFF/LOGON replies, so it must read the LOGON result itself.
+          connection.authenticate(auth_token, force: true, pipelined: false)
         ensure
           connection.discard_on_release = true
           @connection_provider.release(connection)

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -112,7 +112,7 @@ module TestkitBackend
         'Feature:IdempotentRetries'                         => 'jar',
 
         # --- Optimizations ---------------------------------------------------
-        'Optimization:AuthPipelining'                       => 'ja',
+        'Optimization:AuthPipelining'                       => 'jar',
         'Optimization:ConnectionReuse'                      => '',  # disabled in Java too
         'Optimization:EagerTransactionBegin'                => 'jar',
         'Optimization:ExecuteQueryPipelining'               => 'jar',


### PR DESCRIPTION
Closes the MRI gap on `Optimization:AuthPipelining` (`ja` → `jar`).

## What

Bolt 5.1+ re-auth (`Connection#authenticate`) previously did a full round-trip — send LOGOFF+LOGON, flush, and read both SUCCESS replies — before the operation could proceed. Now it **enqueues LOGOFF+LOGON without flushing**; the next operation flushes them alongside its own RUN/BEGIN and consumes the two acks just before reading its own reply. Saves a full round-trip. (HELLO+LOGON was already pipelined.)

## How

- `#drain_pending_auth_acks` runs transparently at the top of `#fetch_response`, consuming the deferred LOGOFF/LOGON replies before the operation's own reply. A **rejected LOGON** raises there as the auth failure (its follow-on message comes back `IGNORED`); the connection is discarded.
- `@pending_auth_acks` tracks the deferred replies; `reset!` (which flushes + drains them with the RESET) clears the counter.
- **`verify_authentication`** re-auths then *discards* the connection with no operation to carry the replies — so it keeps the **synchronous** round-trip (`authenticate(..., pipelined: false)`) and reads the LOGON result itself. This was the one path that broke under blanket pipelining (its non-`_pipelined` scripts expect the flushed sequence).

## Testing

rust boltstub (MRI backend): **`tests.stub.authorization` 168/168** (2 skips) — re-auth, user switching (direct + routing), all auth schemes, token-expired retry, and `verify_authentication`, all green with the `_pipelined` script variants the feature selects.
No regressions: `tx_run`, `iteration`, `disconnects`, `errors`, `summary`, `driver_execute_query`, `idempotent_retries`, `optimizations`, `homedb`; MRI unit specs 69/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authentication handling to support pipelined session re-authentication, reducing unnecessary waiting during connection use.
  * Enabled authentication pipelining for the Java driver feature set.

* **Bug Fixes**
  * Ensured authentication responses are processed correctly during verification and connection resets.
  * Prevented pending authentication responses from carrying over between connection cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->