### PR TITLE
feat(mri): advertise Optimization:ImplicitDefaultArguments

### DIFF
--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -118,7 +118,7 @@ module TestkitBackend
         'Optimization:ExecuteQueryPipelining'               => 'jar',
         'Optimization:HomeDatabaseCache'                    => 'ja',
         'Optimization:HomeDbCacheBasicPrincipalIsImpersonatedUser'  => '',
-        'Optimization:ImplicitDefaultArguments'             => 'ja',
+        'Optimization:ImplicitDefaultArguments'             => 'jar',
         'Optimization:MinimalBookmarksSet'                  => '',
         'Optimization:MinimalResets'                        => '',  # disabled in Java too
         'Optimization:MinimalVerifyAuthentication'          => '',

--- a/testkit-backend/requests/start_test.rb
+++ b/testkit-backend/requests/start_test.rb
@@ -34,8 +34,6 @@ module TestkitBackend
           'Driver rejects empty query strings client-side (like Java/JS)',
         /\.TestAuthenticationSchemes[^.]+\.test_custom_scheme_empty\z/ =>
           'This test needs updating to implement expected behaviour',
-        /\.TestOptimizations\.test_uses_implicit_default_arguments(?:_multi_query(?:_nested)?)?\z/ =>
-          'Driver does not implement optimization for qid in explicit transaction',
         /\.TestResultSingle\.test_result_single_with_2_records\z/ =>
           'This test needs updating to implement expected behaviour',
         /\Astub\.routing\.test_routing_v[^.]*\.RoutingV[^.]*\.test_ipv6_read/ =>
@@ -88,7 +86,13 @@ module TestkitBackend
           # stays advertised (the TestLivenessCheck config tests pass). NOT
           # skipped on MRI — MRI must implement pool metrics.
           /\.test_should_drop_connections_failing_liveness_check\z/ =>
-            'get_connection_pool_metrics blocked on JRuby (shaded-jar ABI clash); deferred unshaded-jar migration'
+            'get_connection_pool_metrics blocked on JRuby (shaded-jar ABI clash); deferred unshaded-jar migration',
+          # The Java driver doesn't omit qid in an explicit transaction, so it
+          # fails these under Optimization:ImplicitDefaultArguments (testkit's
+          # Java backend skips them too). MRI does omit it — the current query's
+          # PULL/DISCARD carries no qid — so MRI runs and passes them.
+          /\.TestOptimizations\.test_uses_implicit_default_arguments(?:_multi_query(?:_nested)?)?\z/ =>
+            'Java driver does not omit qid in an explicit transaction; MRI does'
         }.freeze,
         mri: {}.freeze
       }.freeze


### PR DESCRIPTION
Closes the MRI gap on `Optimization:ImplicitDefaultArguments` (`ja` → `jar`).

## What

"The driver doesn't explicitly send message data that is the default value." MRI **already** does this:
- RUN/BEGIN extras drop blank/default keys (`reject!(&Internal::Extras::BLANK)`)
- PULL/DISCARD send `qid` only for a demoted result (never the `-1` default)
- `AuthTokens.basic` omits an absent `realm`
- HELLO drops an unset routing context

So the optimization is already satisfied — this claims it, **and removes a now-stale backend skip** for `TestOptimizations.test_uses_implicit_default_arguments{,_multi_query,_nested}`. That skip ("Driver does not implement optimization for qid in explicit transaction") no longer holds — MRI omits `qid` for the current query in an explicit tx, so those tests pass.

## Testing

Every `OPT_IMPLICIT_DEFAULT_ARGUMENTS`-gated suite passes with its `_minimal` / `_pipelined_minimal` scripts (which *require* the omissions):
- `authorization` **168/168** (`_pipelined_minimal` LOGON — no empty `realm`)
- `optimizations` — `test_uses_implicit_default_arguments{,_multi_query,_nested}` now **run and pass** (previously skipped)
- `routing.test_no_routing_v4x2`, `disconnects` — OK

No regressions with the flag on: `iteration` 56/0, `tx_run` 19/0, `summary` 132/0, `driver_execute_query` 15/0, `homedb` 37/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)