### PR TITLE
feat(mri): mutual-TLS client certificates [Feature:API:SSLClientCertificate]

### DIFF
--- a/lib/jruby/neo4j/driver.rb
+++ b/lib/jruby/neo4j/driver.rb
@@ -52,6 +52,7 @@ end
 Java::JavaUtil::Map.include Neo4j::Driver::Ext::PlainMapConverter
 Java::OrgNeo4jDriver::AuthTokens.singleton_class.prepend Neo4j::Driver::Ext::AuthTokens
 Java::OrgNeo4jDriver::BookmarkManagers.singleton_class.prepend Neo4j::Driver::Ext::BookmarkManagers
+Java::OrgNeo4jDriver::ClientCertificates.singleton_class.prepend Neo4j::Driver::Ext::ClientCertificates
 Java::OrgNeo4jDriver::GraphDatabase.singleton_class.prepend Neo4j::Driver::Ext::GraphDatabase
 Java::OrgNeo4jDriver::Query.prepend Neo4j::Driver::Ext::Query
 Java::OrgNeo4jDriverInternal::DelegatingTransactionContext.prepend Neo4j::Driver::Ext::Internal::AbstractQueryRunner

--- a/lib/jruby/neo4j/driver/ext/client_certificates.rb
+++ b/lib/jruby/neo4j/driver/ext/client_certificates.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Driver
+    module Ext
+      # Ruby-friendly surface over org.neo4j.driver.ClientCertificates,
+      # prepended onto its singleton class (cf. Ext::GraphDatabase /
+      # Ext::BookmarkManagers) rather than shadowing the Java class. Lets the
+      # flavour-agnostic testkit backend call
+      # ClientCertificates.of(certpath, keypath[, password]) with path strings;
+      # the Java factory takes java.io.File, so wrap and delegate via super.
+      module ClientCertificates
+        def of(certfile, keyfile, password = nil)
+          cert = java.io.File.new(certfile.to_s)
+          key = java.io.File.new(keyfile.to_s)
+          password ? super(cert, key, password) : super(cert, key)
+        end
+      end
+    end
+  end
+end

--- a/lib/mri/neo4j/driver/bolt/tls_config.rb
+++ b/lib/mri/neo4j/driver/bolt/tls_config.rb
@@ -36,6 +36,7 @@ module Neo4j
           ctx = OpenSSL::SSL::SSLContext.new
           ctx.min_version = OpenSSL::SSL::TLS1_2_VERSION
           apply_trust(ctx)
+          apply_client_certificate(ctx)
           ctx
         end
 
@@ -50,6 +51,22 @@ module Neo4j
         end
 
         private
+
+        # Mutual TLS (Feature:API:SSLClientCertificate): present the client
+        # certificate the manager currently holds. Polled per connection so a
+        # rotated certificate takes effect on the next connect; nil manager or
+        # nil certificate leaves the context client-cert-free.
+        def apply_client_certificate(ctx)
+          certificate = @options[:client_certificate_manager]&.get_client_certificate
+          return unless certificate
+
+          ctx.cert = OpenSSL::X509::Certificate.new(File.read(certificate.certfile))
+          # PKey.read handles both encrypted (password used) and unencrypted
+          # (password ignored) PEM keys. Pass "" rather than nil for a missing
+          # password so an encrypted key raises PKeyError instead of blocking
+          # the thread on OpenSSL's interactive stdin passphrase prompt.
+          ctx.key = OpenSSL::PKey.read(File.read(certificate.keyfile), certificate.password || '')
+        end
 
         def apply_trust(ctx)
           case resolved_strategy

--- a/lib/mri/neo4j/driver/client_certificate.rb
+++ b/lib/mri/neo4j/driver/client_certificate.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Driver
+    # A client certificate for mutual TLS (Feature:API:SSLClientCertificate):
+    # the certificate PEM file, its private-key PEM file, and the key's
+    # optional password. Built via ClientCertificates.of and served by a
+    # ClientCertificateManager. Mirrors org.neo4j.driver.ClientCertificate.
+    class ClientCertificate
+      attr_reader :certfile, :keyfile, :password
+
+      def initialize(certfile, keyfile, password = nil)
+        @certfile = certfile
+        @keyfile = keyfile
+        @password = password
+      end
+    end
+  end
+end

--- a/lib/mri/neo4j/driver/client_certificate_manager.rb
+++ b/lib/mri/neo4j/driver/client_certificate_manager.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Driver
+    # Supplies the current client certificate for mutual TLS
+    # (Feature:API:SSLClientCertificate). Wrap a block that returns a
+    # ClientCertificate — or nil when nothing changed since the last call, in
+    # which case the previously supplied certificate is kept. Pass an instance
+    # to GraphDatabase.driver via `client_certificate_manager:`; the driver
+    # consults it whenever a connection needs a (possibly rotated) certificate.
+    #
+    # The MRI counterpart of the Java driver's org.neo4j.driver
+    # .ClientCertificateManager (whose get returns null for "no change"); the
+    # last non-nil certificate is retained here so a fresh per-connection TLS
+    # context always presents the current one.
+    class ClientCertificateManager
+      def initialize(&get_client_certificate)
+        @get_client_certificate = get_client_certificate
+        @current = nil
+        @mutex = Mutex.new
+      end
+
+      # The current client certificate. Polls the block; a non-nil result
+      # rotates the retained certificate, a nil result keeps it. Connections
+      # are acquired concurrently, so the poll-and-update is serialized: it
+      # keeps @current consistent and stops a blocking provider (the testkit
+      # callback round-trips to the frontend) from being entered concurrently.
+      def get_client_certificate
+        @mutex.synchronize do
+          certificate = @get_client_certificate.call
+          @current = certificate if certificate
+          @current
+        end
+      end
+    end
+  end
+end

--- a/lib/mri/neo4j/driver/client_certificate_managers.rb
+++ b/lib/mri/neo4j/driver/client_certificate_managers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Driver
+    # Factory for ClientCertificateManager, mirroring
+    # org.neo4j.driver.ClientCertificateManagers.
+    module ClientCertificateManagers
+      # A manager that presents the given (static) client certificate on every
+      # request — the non-rotating case.
+      def self.rotating(client_certificate)
+        ClientCertificateManager.new { client_certificate }
+      end
+    end
+  end
+end

--- a/lib/mri/neo4j/driver/client_certificates.rb
+++ b/lib/mri/neo4j/driver/client_certificates.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Neo4j
+  module Driver
+    # Factory for ClientCertificate, mirroring org.neo4j.driver.ClientCertificates.
+    # Accepts path strings (or anything with #to_s, e.g. a Pathname) for the
+    # certificate and private-key PEM files, plus the key's optional password.
+    module ClientCertificates
+      def self.of(certfile, keyfile, password = nil)
+        ClientCertificate.new(certfile.to_s, keyfile.to_s, password)
+      end
+    end
+  end
+end

--- a/lib/mri/neo4j/driver/internal/driver_factory.rb
+++ b/lib/mri/neo4j/driver/internal/driver_factory.rb
@@ -45,12 +45,14 @@ module Neo4j
         # stays agnostic.
         def create_clock = Internal::Clock.new
 
-        # `client_certificate_manager` is accepted for a uniform cross-impl
-        # signature but ignored — MRI doesn't implement mutual-TLS client
-        # certificates (Feature:API:SSLClientCertificate is JRuby-only), and
-        # testkit never supplies one to the MRI flavour.
+        # Mutual-TLS client certificates (Feature:API:SSLClientCertificate): the
+        # ClientCertificateManager is threaded into the options every connection's
+        # TlsConfig reads, so each connection's SSL context presents the current
+        # (rotatable) client certificate. nil (the common case) leaves TLS
+        # unchanged.
         def new_instance(uri, auth_token_manager, client_certificate_manager: nil, **config)
           validate_uri(uri)
+          config = config.merge(client_certificate_manager: client_certificate_manager) if client_certificate_manager
           # The factory is the single place that knows about the non-public
           # extension hooks (the domain-name resolver and the clock). It
           # assembles a fully-wired ConnectionProvider with

--- a/testkit-backend/request.rb
+++ b/testkit-backend/request.rb
@@ -12,6 +12,13 @@ module TestkitBackend
       from(request).to_object
     end
 
+    # Build a ClientCertificate (mutual TLS) from a testkit ClientCertificate's
+    # `data` map. Flavour-agnostic: ClientCertificates.of takes path strings on
+    # MRI and wraps them for the Java factory on JRuby.
+    def self.client_certificate_from(cert)
+      Neo4j::Driver::ClientCertificates.of(cert[:certfile], cert[:keyfile], cert[:password])
+    end
+
     def initialize(hash, command_processor)
       @data = hash
       @command_processor = command_processor

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -96,7 +96,7 @@ module TestkitBackend
         'Feature:API:RetryableExceptions'                   => 'jar',
         'Feature:API:Session:AuthConfig'                    => 'jar',
         'Feature:API:Session:NotificationsConfig'           => 'jar',
-        'Feature:API:SSLClientCertificate'                  => 'ja', # JRuby: ClientCertificateManager via DriverFactory; MRI mTLS not wired
+        'Feature:API:SSLClientCertificate'                  => 'jar', # ClientCertificateManager -> TlsConfig (MRI) / DriverFactory (JRuby)
         'Feature:API:SSLConfig'                             => 'jar',
         'Feature:API:SSLSchemes'                            => 'jar',
         'Feature:API:Summary:GqlStatusObjects'              => 'jar',

--- a/testkit-backend/requests/new_client_certificate_provider.rb
+++ b/testkit-backend/requests/new_client_certificate_provider.rb
@@ -28,14 +28,7 @@ module TestkitBackend
         return unless completed.has_update
 
         # The wire shape nests the cert fields under `data`.
-        cert = completed.client_certificate[:data]
-        cert_file = java.io.File.new(cert[:certfile])
-        key_file = java.io.File.new(cert[:keyfile])
-        if cert[:password]
-          Neo4j::Driver::ClientCertificates.of(cert_file, key_file, cert[:password])
-        else
-          Neo4j::Driver::ClientCertificates.of(cert_file, key_file)
-        end
+        Request.client_certificate_from(completed.client_certificate[:data])
       end
     end
   end

--- a/testkit-backend/requests/new_driver.rb
+++ b/testkit-backend/requests/new_driver.rb
@@ -50,28 +50,19 @@ module TestkitBackend
 
       private
 
-      # Mutual-TLS client certificate (JRuby only — Feature:API:SSLClient-
-      # Certificate). testkit sends exactly one of `clientCertificate` (a
-      # static cert, wrapped in a rotating manager like Java's backend) or
-      # `clientCertificateProviderId` (a managed provider created earlier by
-      # NewClientCertificateProvider). nil on MRI, where neither is ever set.
+      # Mutual-TLS client certificate (Feature:API:SSLClientCertificate).
+      # testkit sends exactly one of `clientCertificate` (a static cert, wrapped
+      # in a rotating manager like Java's backend) or `clientCertificateProviderId`
+      # (a managed provider created earlier by NewClientCertificateProvider). nil
+      # when neither is set.
       def client_certificate_manager
         if client_certificate_provider_id
           fetch(client_certificate_provider_id)
         elsif client_certificate
           # The wire shape nests the fields under `data` (Java reads
           # ClientCertificate#getData()), so unwrap before building.
-          Neo4j::Driver::ClientCertificateManagers.rotating(to_client_certificate(client_certificate[:data]))
-        end
-      end
-
-      def to_client_certificate(cert)
-        cert_file = java.io.File.new(cert[:certfile])
-        key_file = java.io.File.new(cert[:keyfile])
-        if cert[:password]
-          Neo4j::Driver::ClientCertificates.of(cert_file, key_file, cert[:password])
-        else
-          Neo4j::Driver::ClientCertificates.of(cert_file, key_file)
+          Neo4j::Driver::ClientCertificateManagers.rotating(
+            Request.client_certificate_from(client_certificate[:data]))
         end
       end
 


### PR DESCRIPTION
## Summary

Implements the `ClientCertificate` / `ClientCertificateManager` API for the **MRI** flavour so the pure-Ruby Bolt driver can present a client certificate during the TLS handshake (mutual TLS). This closes the `Feature:API:SSLClientCertificate` testkit gap — JRuby already advertised it via the Java driver; MRI now advertises it too.

## What's here

- **`ClientCertificate`** value object + **`ClientCertificates.of(certfile, keyfile, password = nil)`** factory.
- **`ClientCertificateManager`** — block-based; caches the last non-nil certificate so a `nil` reply means "keep the current one" (matches Java semantics). **`ClientCertificateManagers.rotating(cert)`** helper.
- **`DriverFactory#new_instance`** threads the manager into the per-connection options (previously accepted-but-ignored on MRI).
- **`TlsConfig#apply_client_certificate`** polls the manager on each connect and sets `ctx.cert` / `ctx.key`. `OpenSSL::PKey.read` handles both encrypted (password) and plain PEM keys. Polling per-connect is what makes **rotation** work — the next connection picks up a rotated cert.
- **JRuby flavour**: `ClientCertificates` / `ClientCertificateManagers` delegate to the Java factories (wrapping paths in `java.io.File`), keeping the testkit backend flavour-agnostic.
- **Backend**: flavour-agnostic `Request.client_certificate_from` + `NewClientCertificateProvider` round-trips to the frontend for cert updates (blocking, like `NewAuthTokenManager`).
- Advertise `Feature:API:SSLClientCertificate` for both flavours.

## Validation

Ran `tests.tls.test_client_certificate` locally against the MRI backend (CRuby) with the test CA trusted — **all 5 cases pass**:

- `neo4j+s` / `bolt+s` with client certificate present
- `neo4j+ssc` / `bolt+ssc` (trust-all) with and without client certificate
- `+s` / `+ssc` with certificate not present
- **client rotation** (`TestClientCertificateRotation`)

CI `testkit-tls (mri)` will exercise the `+s` schemes in the Docker environment where the test CA is imported into the trust store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added mutual TLS client-certificate support for MRI and JRuby.
  - Added APIs for creating and rotating client certificates.
  - Added support for encrypted private keys.
  - Enabled client certificates in driver connections and advertised SSL client-certificate support across platforms.

- **Bug Fixes**
  - Fixed client-certificate settings not being applied to MRI driver connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->