### PR TITLE
feat(mri): preserve absent profile stats [Feature:API:Summary:Profile:OptionalStats]

### DIFF
--- a/lib/mri/neo4j/driver/summary/profile.rb
+++ b/lib/mri/neo4j/driver/summary/profile.rb
@@ -3,20 +3,24 @@
 module Neo4j
   module Driver
     module Summary
-      # Plan plus per-step execution stats (db_hits, rows). Mirrors
-      # org.neo4j.driver.summary.ProfiledPlan.
+      # Plan plus per-step execution stats. Mirrors the driver-6.2 public
+      # QueryProfile, whose getters are all optional: an absent stat stays
+      # nil (distinguishable from a real 0) rather than collapsing to 0, so
+      # the backend can omit it — Feature:API:Summary:Profile:OptionalStats.
+      # The JRuby flavor gets the same nil-vs-0 distinction from
+      # Ext::Internal::Summary::InternalQueryProfile.
       class Profile < Plan
         attr_reader :db_hits, :records, :page_cache_hits, :page_cache_misses,
                     :page_cache_hit_ratio, :time
 
         def initialize(profile_data)
           super
-          @db_hits = profile_data[:dbHits] || 0
-          @records = profile_data[:rows] || profile_data[:records] || 0
-          @page_cache_hits = profile_data[:pageCacheHits] || 0
-          @page_cache_misses = profile_data[:pageCacheMisses] || 0
-          @page_cache_hit_ratio = profile_data[:pageCacheHitRatio] || 0.0
-          @time = profile_data[:time] || 0
+          @db_hits = profile_data[:dbHits]
+          @records = profile_data[:rows] || profile_data[:records]
+          @page_cache_hits = profile_data[:pageCacheHits]
+          @page_cache_misses = profile_data[:pageCacheMisses]
+          @page_cache_hit_ratio = profile_data[:pageCacheHitRatio]
+          @time = profile_data[:time]
         end
       end
     end

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -106,7 +106,7 @@ module TestkitBackend
         # jruby maps the 6.2 QueryProfile's Optional stats (empty -> nil ->
         # omitted); MRI's summary hydration still defaults absent stats to 0,
         # so it stays off there for now.
-        'Feature:API:Summary:Profile:OptionalStats'         => 'ja',
+        'Feature:API:Summary:Profile:OptionalStats'         => 'jar',
         'Feature:API:Type.Spatial'                          => '',
         'Feature:API:Type.Temporal'                         => 'jar',  # jruby wraps Java temporal types; MRI hydrates to Ruby Time/Types and defers unresolvable zone ids (Types::UnresolvableZonedDateTime)
         'Feature:API:Type.UnsupportedType'                  => 'jar',

--- a/testkit-backend/requests/get_features.rb
+++ b/testkit-backend/requests/get_features.rb
@@ -103,9 +103,6 @@ module TestkitBackend
         'Feature:API:SSLConfig'                             => 'jar',
         'Feature:API:SSLSchemes'                            => 'jar',
         'Feature:API:Summary:GqlStatusObjects'              => 'jar',
-        # jruby maps the 6.2 QueryProfile's Optional stats (empty -> nil ->
-        # omitted); MRI's summary hydration still defaults absent stats to 0,
-        # so it stays off there for now.
         'Feature:API:Summary:Profile:OptionalStats'         => 'jar',
         'Feature:API:Type.Spatial'                          => '',
         'Feature:API:Type.Temporal'                         => 'jar',  # jruby wraps Java temporal types; MRI hydrates to Ruby Time/Types and defers unresolvable zone ids (Types::UnresolvableZonedDateTime)

--- a/testkit-backend/requests/start_test.rb
+++ b/testkit-backend/requests/start_test.rb
@@ -20,7 +20,6 @@ module TestkitBackend
           'Contains updates because value is over zero',
         /\.test_partial_summary_not_contains_updates\z/ =>
           'Contains updates because value is over zero',
-        /\.test_profile\z/ => 'Missing stats are reported with 0 value',
         /\.test_server_info\z/ => 'Address includes domain name',
         /\.test_partial_summary_contains_system_updates\z/ =>
           'Does not contain updates because value is zero',


### PR DESCRIPTION
## Summary

Closes the `Feature:API:Summary:Profile:OptionalStats` gap for the **MRI** flavour (JRuby already advertised it via the 6.2 Java driver).

MRI's `Profile` collapsed every absent profile stat to `0` (`profile_data[:pageCacheHits] || 0`), so an unmeasured stat looked identical to a real `0`. This mirrors the driver-6.2 public `QueryProfile`, whose getters are all *optional* — an absent stat stays `nil` so the backend can omit it.

## Changes

- **`lib/mri/.../summary/profile.rb`** — keep `db_hits` / `records` / `page_cache_hits` / `page_cache_misses` / `page_cache_hit_ratio` / `time` `nil` when the server didn't send them (drop the `|| 0` defaults). Matches the JRuby flavour's `Ext::Internal::Summary::InternalQueryProfile` (OptionalLong/Double → value or nil).
- **`get_features.rb`** — advertise the feature for MRI (`ja` → `jar`).
- **`start_test.rb`** — drop the now-stale COMMON skip of `test_profile` (*"Missing stats are reported with 0 value"*). It was skipping the test on **both** flavours even though JRuby already implemented this.

The backend needed no change — `plan_to_h` already `.compact`s nil optional stats (a present `0` stays).

## Validation

Ran `tests.stub.summary.test_summary` on the MRI backend — full suite green:
- `test_profile` (now unskipped) passes on `TestSummaryPlan{4x4,6x0}` and their Discard variants
- `test_profile_no_db_hit`, `test_profile_no_time`, `test_profile_no_rows`, `test_profile_no_page_cache_stats` all pass (absent stats reported as nil, not 0)

No regression to the integration `summary_spec` (`db_hits == 0` there is a *real* 0 the server sends for `RETURN 1`, not an absent stat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved unavailable query-profile statistics as unspecified (nil) instead of displaying them as zero.
  * Improved handling of backends that omit optional execution statistics fields.

* **Testkit**
  * Updated feature support reporting for optional profile statistics (now enabled for the Java/JRuby flavour).
  * Re-enabled profile-related test coverage by removing the skip for profile requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->