### PR TITLE
chore(dependencies): bump neo4j-java-driver version to 6.2.1 in gemspec

### DIFF
--- a/lib/shared/neo4j/driver/version.rb
+++ b/lib/shared/neo4j/driver/version.rb
@@ -2,6 +2,6 @@
 
 module Neo4j
   module Driver
-    VERSION = '0.1.0'
+    VERSION = '6.2.1-beta.1'
   end
 end

--- a/neo4j-ruby-driver-java.gemspec
+++ b/neo4j-ruby-driver-java.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'concurrent-ruby-edge', '>= 0.6.0'
   spec.add_dependency 'jar-dependencies', '>= 0.5.5'
   spec.add_development_dependency 'ruby-maven', '>= 0'
-  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-all, 6.2.0'
-  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-observation-metrics, 6.2.0'
+  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-all, 6.2.1'
+  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-observation-metrics, 6.2.1'
   # spec.requirements << 'jar org.neo4j.bolt, neo4j-bolt-connection-pooled, 10.1.0'
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Neo4j Java driver and observation metrics components to version 6.2.1.
  * Includes the latest upstream maintenance updates and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->