### PR TITLE
ci: version-stable *-success gates for branch protection

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -98,3 +98,19 @@ jobs:
 
       - name: Run RSpec
         run: bundle exec rspec --format progress
+
+  # Stable, version-free gate for branch protection. Requiring the matrix
+  # legs directly would embed the Ruby/Neo4j versions in the required-check
+  # names, so bumping the matrix would silently strip the requirement. This
+  # gate's name never changes; require `rspec-success` in the ruleset instead.
+  rspec-success:
+    name: rspec-success
+    needs: [rspec]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the rspec matrix to pass
+        if: ${{ needs.rspec.result != 'success' }}
+        run: |
+          echo "rspec matrix result: ${{ needs.rspec.result }}"
+          exit 1

--- a/.github/workflows/testkit-stub.yml
+++ b/.github/workflows/testkit-stub.yml
@@ -124,3 +124,17 @@ jobs:
           name: testkit-stub-artifacts-${{ matrix.flavor }}
           path: ${{ env.TESTKIT_PATH }}/artifacts/
           if-no-files-found: ignore
+
+  # Stable, version-free gate for branch protection (see specs.yml). Require
+  # `testkit-stub-success` in the ruleset rather than the per-flavor matrix legs.
+  testkit-stub-success:
+    name: testkit-stub-success
+    needs: [testkit-stub]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the testkit-stub matrix to pass
+        if: ${{ needs.testkit-stub.result != 'success' }}
+        run: |
+          echo "testkit-stub matrix result: ${{ needs.testkit-stub.result }}"
+          exit 1

--- a/.github/workflows/testkit-stub.yml
+++ b/.github/workflows/testkit-stub.yml
@@ -134,7 +134,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Require the testkit-stub matrix to pass
-        if: ${{ needs.testkit-stub.result != 'success' }}
+        # Bracket notation: a hyphen in the job id is parsed as subtraction
+        # under dot access (needs.testkit-stub → needs.testkit - stub).
+        if: ${{ needs['testkit-stub'].result != 'success' }}
         run: |
-          echo "testkit-stub matrix result: ${{ needs.testkit-stub.result }}"
+          echo "testkit-stub matrix result: ${{ needs['testkit-stub'].result }}"
           exit 1

--- a/.github/workflows/testkit-tls.yml
+++ b/.github/workflows/testkit-tls.yml
@@ -104,7 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Require the testkit-tls matrix to pass
-        if: ${{ needs.testkit-tls.result != 'success' }}
+        # Bracket notation: a hyphen in the job id is parsed as subtraction
+        # under dot access (needs.testkit-tls → needs.testkit - tls).
+        if: ${{ needs['testkit-tls'].result != 'success' }}
         run: |
-          echo "testkit-tls matrix result: ${{ needs.testkit-tls.result }}"
+          echo "testkit-tls matrix result: ${{ needs['testkit-tls'].result }}"
           exit 1

--- a/.github/workflows/testkit-tls.yml
+++ b/.github/workflows/testkit-tls.yml
@@ -94,3 +94,17 @@ jobs:
           name: testkit-tls-artifacts-${{ matrix.flavor }}
           path: ${{ env.TESTKIT_PATH }}/artifacts/
           if-no-files-found: ignore
+
+  # Stable, version-free gate for branch protection (see specs.yml). Require
+  # `testkit-tls-success` in the ruleset rather than the per-flavor matrix legs.
+  testkit-tls-success:
+    name: testkit-tls-success
+    needs: [testkit-tls]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the testkit-tls matrix to pass
+        if: ${{ needs.testkit-tls.result != 'success' }}
+        run: |
+          echo "testkit-tls matrix result: ${{ needs.testkit-tls.result }}"
+          exit 1

--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -125,3 +125,17 @@ jobs:
           name: testkit-artifacts-${{ matrix.flavor }}
           path: ${{ env.TESTKIT_PATH }}/artifacts/
           if-no-files-found: ignore
+
+  # Stable, version-free gate for branch protection (see specs.yml). Require
+  # `testkit-success` in the ruleset rather than the per-flavor matrix legs.
+  testkit-success:
+    name: testkit-success
+    needs: [testkit]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the testkit matrix to pass
+        if: ${{ needs.testkit.result != 'success' }}
+        run: |
+          echo "testkit matrix result: ${{ needs.testkit.result }}"
+          exit 1


### PR DESCRIPTION
Adds a small aggregator job to each PR-triggered workflow so branch protection can require **four stable check names** — `rspec-success`, `testkit-success`, `testkit-stub-success`, `testkit-tls-success` — instead of the ~22 matrix legs whose names embed Ruby/Neo4j versions.

Each gate `needs:` its workflow's matrix job and fails unless that job's aggregate `result == 'success'`. `if: ${{ !cancelled() }}` ensures the gate still runs (and goes red) when the matrix fails. JRuby `continue-on-error` legs already report success, so this preserves today's gating intent.

Prep for the `protect main` ruleset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added stable status checks for RSpec, Testkit, Testkit TLS, and Testkit Stub workflows.
  - Branch protection can now consistently rely on version-independent results across test matrices.
  - Checks accurately report failures and cancellations, improving the reliability of automated validation.
  - Matrix-based testing outcomes are now consolidated into dependable checks for easier monitoring and release readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->