### PR TITLE
ci: skip heavy CI on housekeeping-only changes

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -6,9 +6,9 @@ on:
     # Housekeeping-only changes (docs, changelog, version bump) can't affect
     # tests — skip the heavy CI on them. A mixed change still runs (paths-ignore
     # skips only when EVERY changed file matches).
-    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
+    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
   pull_request:
-    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
+    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
 
 jobs:
   rspec:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -3,7 +3,12 @@ name: Driver specs
 on:
   push:
     branches: [main]
+    # Housekeeping-only changes (docs, changelog, version bump) can't affect
+    # tests — skip the heavy CI on them. A mixed change still runs (paths-ignore
+    # skips only when EVERY changed file matches).
+    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
   pull_request:
+    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
 
 jobs:
   rspec:

--- a/.github/workflows/testkit-stub.yml
+++ b/.github/workflows/testkit-stub.yml
@@ -6,9 +6,9 @@ on:
     # Housekeeping-only changes (docs, changelog, version bump) can't affect
     # tests — skip the heavy CI on them. A mixed change still runs (paths-ignore
     # skips only when EVERY changed file matches).
-    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
+    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
   pull_request:
-    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
+    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
 
 jobs:
   testkit-stub:

--- a/.github/workflows/testkit-stub.yml
+++ b/.github/workflows/testkit-stub.yml
@@ -3,7 +3,12 @@ name: Testkit (stub)
 on:
   push:
     branches: [main]
+    # Housekeeping-only changes (docs, changelog, version bump) can't affect
+    # tests — skip the heavy CI on them. A mixed change still runs (paths-ignore
+    # skips only when EVERY changed file matches).
+    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
   pull_request:
+    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
 
 jobs:
   testkit-stub:

--- a/.github/workflows/testkit-tls.yml
+++ b/.github/workflows/testkit-tls.yml
@@ -6,9 +6,9 @@ on:
     # Housekeeping-only changes (docs, changelog, version bump) can't affect
     # tests — skip the heavy CI on them. A mixed change still runs (paths-ignore
     # skips only when EVERY changed file matches).
-    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
+    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
   pull_request:
-    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
+    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
 
 jobs:
   testkit-tls:

--- a/.github/workflows/testkit-tls.yml
+++ b/.github/workflows/testkit-tls.yml
@@ -3,7 +3,12 @@ name: Testkit (TLS)
 on:
   push:
     branches: [main]
+    # Housekeeping-only changes (docs, changelog, version bump) can't affect
+    # tests — skip the heavy CI on them. A mixed change still runs (paths-ignore
+    # skips only when EVERY changed file matches).
+    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
   pull_request:
+    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
 
 jobs:
   testkit-tls:

--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -6,9 +6,9 @@ on:
     # Housekeeping-only changes (docs, changelog, version bump) can't affect
     # tests — skip the heavy CI on them. A mixed change still runs (paths-ignore
     # skips only when EVERY changed file matches).
-    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
+    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
   pull_request:
-    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
+    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
 
 jobs:
   testkit:

--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -3,7 +3,12 @@ name: Testkit
 on:
   push:
     branches: [main]
+    # Housekeeping-only changes (docs, changelog, version bump) can't affect
+    # tests — skip the heavy CI on them. A mixed change still runs (paths-ignore
+    # skips only when EVERY changed file matches).
+    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
   pull_request:
+    paths-ignore: ['**.md', 'lib/shared/neo4j/driver/version.rb']
 
 jobs:
   testkit:


### PR DESCRIPTION
Adds `paths-ignore` (`**.md`, `version.rb`) to the `push` and `pull_request` triggers of the four heavy workflows, so doc/changelog/version-bump-only changes don't run the rspec matrix or the testkit suites.

- A **mixed** change (code + docs) still runs — `paths-ignore` skips only when *every* changed file matches.
- Pairs with the **repo-admin `always` bypass** just added to the `protect main` ruleset, so housekeeping can land directly on `main` with no PR and no CI.

**Trade-off (intended):** a non-bypass contributor's docs-only PR would leave the required `*-success` checks unreported (the workflow is skipped) and need an admin to bypass-merge it. Acceptable for a solo-maintained repo.

This PR itself touches only workflow files, so it runs full CI and is mergeable normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation workflows to skip runs for documentation-only changes and driver version updates.
  * Validation continues to run when changes include source code or other relevant files.
  * Reduced unnecessary CI activity while preserving checks for mixed or functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->