### PR TITLE
fix(mri): Record#to_h returns symbol keys, matching JRuby

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,8 @@ lib/jruby/neo4j/driver/           JRuby implementation: thin wrapper over the
 
 ## API conventions
 
-- Node labels, relationship types, and field keys → symbols (converted at hydration).
-- Record property keys stored as strings; accessible via string *or* symbol.
+- Node labels, relationship types, field keys, and property keys → symbols (converted at hydration).
+- All keys are stored as symbols; retrieval by string is tolerated (`Record#[]` / `Entity#[]` coerce with `to_sym`).
 - `session.run(query, parameters = {}, config = {})` — explicit split. Same key allowed in both hashes.
 - Timeouts are seconds (or `ActiveSupport::Duration`); converted to ms for the Bolt wire internally.
 - Bookmarks are **replaced** on each successful commit, not accumulated. `session.last_bookmarks` returns a Set of 0 or 1. Rollback, failure, and auto-commit queries do not update them.

--- a/lib/mri/neo4j/driver/record.rb
+++ b/lib/mri/neo4j/driver/record.rb
@@ -7,10 +7,10 @@ module Neo4j
       def initialize(keys, values)
         @keys = keys
         @values = values
-        # keys arrive already symbolized (Session/Transaction map the RUN
-        # response fields with &:to_sym), so the map is symbol-keyed — to_h
-        # then returns symbol keys, matching the JRuby flavour and the rest
-        # of the API (labels, rel types, property keys are all symbols).
+        # Field keys arrive already symbolized (Session/Transaction map the
+        # RUN response fields with &:to_sym), so the map is symbol-keyed and
+        # to_h returns symbol keys like the JRuby flavour. Every key in the
+        # driver is stored as a symbol; retrieval by string is tolerated (#[]).
         @map = keys.zip(values).to_h
       end
 

--- a/lib/mri/neo4j/driver/record.rb
+++ b/lib/mri/neo4j/driver/record.rb
@@ -7,11 +7,11 @@ module Neo4j
       def initialize(keys, values)
         @keys = keys
         @values = values
-        # Create map with string keys for consistent lookup
-        @map = {}
-        @keys.each_with_index do |key, idx|
-          @map[key.to_s] = @values[idx]
-        end
+        # keys arrive already symbolized (Session/Transaction map the RUN
+        # response fields with &:to_sym), so the map is symbol-keyed — to_h
+        # then returns symbol keys, matching the JRuby flavour and the rest
+        # of the API (labels, rel types, property keys are all symbols).
+        @map = keys.zip(values).to_h
       end
 
       attr_reader :keys, :values
@@ -21,7 +21,7 @@ module Neo4j
         when Integer
           @values[key]
         when String, Symbol
-          @map[key.to_s]
+          @map[key.to_sym]
         else
           raise ArgumentError, "Invalid key type: #{key.class}"
         end

--- a/spec/shared/neo4j/driver/record_spec.rb
+++ b/spec/shared/neo4j/driver/record_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Record' do
+  subject(:record) do
+    driver.session { |session| session.run('RETURN 1 AS a, 2 AS b').single }
+  end
+
+  it 'exposes symbol keys' do
+    expect(record.keys).to eq %i[a b]
+  end
+
+  describe '#to_h' do
+    it 'returns a symbol-keyed map (matching the field keys), not string keys' do
+      expect(record.to_h).to eq(a: 1, b: 2)
+    end
+  end
+
+  describe '#[]' do
+    it 'looks up by symbol' do
+      expect(record[:a]).to eq 1
+    end
+
+    it 'looks up by string too' do
+      expect(record['b']).to eq 2
+    end
+
+    it 'looks up by positional index' do
+      expect(record[0]).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
## Problem

On the **MRI** flavour, `Record#to_h` returned **string** keys:

```ruby
record.to_h   # => {"a" => 1, "b" => 2}   (MRI, wrong)
record.to_h   # => {a: 1, b: 2}           (JRuby, correct)
```

Everything else in the API is symbol-keyed — `record.keys`, node labels, relationship types, property keys — and JRuby's `Record#to_h` (via `MapConverter`/`as_ruby_object`) returns symbols. Only MRI diverged.

## Cause

The RUN response fields are already symbolized by `Session`/`Transaction` (`… .map(&:to_sym)`), so `record.keys` was correct. But `Record#initialize` rebuilt its lookup map with `key.to_s`, stringifying them — and `to_h` returns that map.

## Fix

Key the map by the (already-symbol) field keys directly, and coerce `[]` lookups with `to_sym` so string access keeps working:

```ruby
@map = keys.zip(values).to_h          # was: @map[key.to_s] = value in a loop
…
when String, Symbol then @map[key.to_sym]   # was: @map[key.to_s]
```

Now `to_h` yields `{a: 1, b: 2}`, and `record[:a]`, `record['a']`, `record['a.name']`, `record[0]` all still resolve.

## Tests

New shared spec `record_spec.rb` (runs on both flavours) pins symbol-keyed `to_h`, symbol `keys`, and symbol/string/positional `[]` access. Green on MRI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Neo4j record field access for consistent lookups using symbol names, string names, or positional indexes.
  * Ensured record hash conversions expose symbol-keyed fields consistently.

* **Tests**
  * Added coverage for record key exposure, hash conversion, and supported lookup methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->