### PR TITLE
build(jruby): vendor Java-driver jars, zero Maven at install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ pkg/
 
 *.jar
 neo4j-ruby-driver_jars.rb
+# Regenerated from the gemspec jar requirements by `rake build:jruby`.
+Jars.lock
 
 # Populated by testkit's _ensure_image() before docker build
 # (CAs/ from testkit's tests/tls/certs/driver/trusted,

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -269,3 +269,37 @@ must be forced to fixed second-lengths). Callers that need it decompose via
 Companion doc with illustrative helpers for both directions + the round-trip
 fixed-point analysis: `docs/duration-conversion.md` (rendered version:
 https://claude.ai/code/artifact/c7c90005-843e-4d2f-a578-f3ca4a29472b).
+
+## 2026-08-13 — JRuby gem vendors the Java-driver jars, zero Maven at install
+
+The `java`-platform gem ships the Neo4j Java-driver jars vendored under `lib/`
+(+ `Jars.lock`), and the published gemspec declares **no** jar `requirements`.
+
+Background: `jar-dependencies` supports two models — vendor the jars in the gem,
+or download them from Maven at install. The gem had drifted into the *worst of
+both*: the jars were vendored (incidentally, because CI's `bundle install` ran
+before `rake build:jruby` and populated `lib/jruby`), **and** install still ran
+Maven — because `Jars::Installer#jars?` fires the post-install hook whenever the
+gem has non-empty `spec.requirements` *and* a runtime `jar-dependencies` dep.
+`Jars.lock` does **not** gate that hook. So a 5 MB gem *and* a Maven round-trip
+(which errors when `ruby-maven` can't be installed).
+
+Decision: make vendoring deliberate and drop the install-time Maven.
+- Under `STAGED_BUILD=1` the java gemspec omits `spec.requirements`, so `jars?`
+  is false and `gem install` runs zero Maven / network. `jar-dependencies` stays
+  a runtime dep so `require_jar` resolves the vendored jars.
+- `rake build:jruby` regenerates the vendored tree deterministically on a clean
+  checkout: `lock_jars --vendor-dir lib/jruby` resolves + vendors + writes
+  `Jars.lock`, then the require manifest (`neo4j-ruby-driver_jars.rb`) is
+  generated *from* `Jars.lock` so it can't drift (the old committed-ish manifest
+  had gone stale at 6.2.0 while requirements said 6.2.1). Maven runs at *build*
+  time only.
+- Vendored jars, `Jars.lock`, and the manifest are all git-ignored — build
+  artifacts, never committed.
+
+Trade-off: the `java` gem stays ~4.9 MB (the shaded `neo4j-java-driver-all` uber
+jar). The alternative — a ~114 KB gem that fetches at install — reintroduces the
+Maven-at-install fragility we already work around with `BUNDLE_JOBS=1` (the
+post-install hook races under parallel installs), plus network/air-gapped
+failures. Reliability over size, matching why nokogiri et al. ship fat platform
+gems. The MRI (`ruby`) gem is unaffected — pure Ruby, no jars, no `Jars.lock`.

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,40 @@ require 'rake/clean'
 
 CLOBBER.include('pkg')
 
+# JRuby only: resolve the Java-driver jars from Maven, vendor them into
+# lib/jruby (maven-repo layout), write Jars.lock, and regenerate the require
+# manifest from that lock. Maven runs at BUILD time only — the published gem
+# declares no jar `requirements` (see neo4j-ruby-driver-java.gemspec), so
+# `gem install` does zero Maven. Deterministic: starts from a clean vendor tree
+# so a fresh checkout yields the same result regardless of prior `bundle install`.
+def regenerate_jruby_jars(root)
+  vendor = File.join(root, 'lib/jruby')
+  # Start clean so stale versions can't accumulate; the manifest is generated
+  # from the lock below, so it can never drift from what is vendored.
+  FileUtils.rm_rf(File.join(vendor, 'org'))
+  FileUtils.rm_f(File.join(root, 'Jars.lock'))
+  # lock_jars reads the jar requirements off the (dev-tree) gemspec, downloads
+  # the dependency tree, copies the jars under vendor/, and writes Jars.lock.
+  Dir.chdir(root) { sh 'lock_jars', '--vendor-dir', vendor }
+  write_jars_manifest(root, vendor)
+end
+
+# Generate lib/jruby/neo4j-ruby-driver_jars.rb from Jars.lock so the runtime
+# require manifest can never pin a version other than what is vendored.
+def write_jars_manifest(root, vendor)
+  entries = File.readlines(File.join(root, 'Jars.lock'))
+                .map(&:strip).reject(&:empty?).map { it.split(':')[0, 3] }
+  lines = ['# frozen_string_literal: true',
+           '# GENERATED from Jars.lock by `rake build:jruby` — do not edit. Loads the',
+           '# vendored jars via require_jar (no Maven / network at install or runtime).',
+           'begin', "  require 'jar_dependencies'", 'rescue LoadError']
+  lines += entries.map { |g, a, v| "  require '#{g.tr('.', '/')}/#{a}/#{v}/#{a}-#{v}.jar'" }
+  lines += ['end', '', 'if defined? Jars']
+  lines += entries.map { |g, a, v| "  require_jar '#{g}', '#{a}', '#{v}'" }
+  lines << 'end'
+  File.write(File.join(vendor, 'neo4j-ruby-driver_jars.rb'), "#{lines.join("\n")}\n")
+end
+
 # Pattern 1 staged build (see JRUBY.md): copy lib/shared/ and lib/<impl>/
 # into a temporary pkg/stage-<impl>/lib/ so the published gem has a flat
 # lib/ tree. Each impl has its own gemspec (neo4j-ruby-driver.gemspec for
@@ -23,12 +57,21 @@ def stage_and_build(impl)
   FileUtils.rm_rf(stage)
   FileUtils.mkdir_p(File.join(stage, 'lib'))
   FileUtils.cp_r(File.join(root, 'lib/shared/.'), File.join(stage, 'lib'))
+  # JRuby: resolve + vendor the Java-driver jars, and regenerate Jars.lock and
+  # the require manifest, so the staged copy below is deterministic on a clean
+  # checkout rather than a side effect of a prior `bundle install`.
+  regenerate_jruby_jars(root) if impl == 'jruby'
   FileUtils.cp_r(File.join(root, "lib/#{impl}/."), File.join(stage, 'lib'))
   FileUtils.mkdir_p(File.join(stage, 'build'))
   FileUtils.cp(File.join(root, 'build/gemspec_common.rb'), File.join(stage, 'build'))
   [gemspec_file, 'README.md', 'LICENSE.txt'].each do |f|
     src = File.join(root, f)
     FileUtils.cp(src, stage) if File.exist?(src)
+  end
+  # JRuby: ship Jars.lock alongside the vendored jars so the published gem pins
+  # exact versions and needs no Maven at install time.
+  if impl == 'jruby' && File.exist?(File.join(root, 'Jars.lock'))
+    FileUtils.cp(File.join(root, 'Jars.lock'), stage)
   end
 
   # Run `gem build` outside Bundler. If we leave Bundler env in place, the

--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,12 @@ CLOBBER.include('pkg')
 # so a fresh checkout yields the same result regardless of prior `bundle install`.
 def regenerate_jruby_jars(root)
   vendor = File.join(root, 'lib/jruby')
-  # Start clean so stale versions can't accumulate; the manifest is generated
-  # from the lock below, so it can never drift from what is vendored.
-  FileUtils.rm_rf(File.join(vendor, 'org'))
+  # Start clean so stale jars can't accumulate. Vendored jars land under maven
+  # group dirs (org/, com/, io/, …) and the manifest is a generated file, so
+  # remove everything under lib/jruby except the Ruby sources (neo4j/).
+  Dir.glob(File.join(vendor, '*')).each do |path|
+    FileUtils.rm_rf(path) unless File.basename(path) == 'neo4j'
+  end
   FileUtils.rm_f(File.join(root, 'Jars.lock'))
   # lock_jars reads the jar requirements off the (dev-tree) gemspec, downloads
   # the dependency tree, copies the jars under vendor/, and writes Jars.lock.

--- a/Rakefile
+++ b/Rakefile
@@ -25,19 +25,40 @@ def regenerate_jruby_jars(root)
 end
 
 # Generate lib/jruby/neo4j-ruby-driver_jars.rb from Jars.lock so the runtime
-# require manifest can never pin a version other than what is vendored.
+# require manifest can never pin a version other than what is vendored. Uses
+# Jars::Lock#process(:runtime), which drops `provided`/`test` entries (only
+# runtime jars are vendored — requiring the others would raise JarLoadError),
+# and `gacv` so classifier coordinates round-trip.
 def write_jars_manifest(root, vendor)
-  entries = File.readlines(File.join(root, 'Jars.lock'))
-                .map(&:strip).reject(&:empty?).map { it.split(':')[0, 3] }
+  require 'jars/lock'
+  jars = []
+  Jars::Lock.new(File.join(root, 'Jars.lock')).process(:runtime) { |jar| jars << jar }
   lines = ['# frozen_string_literal: true',
            '# GENERATED from Jars.lock by `rake build:jruby` — do not edit. Loads the',
            '# vendored jars via require_jar (no Maven / network at install or runtime).',
            'begin', "  require 'jar_dependencies'", 'rescue LoadError']
-  lines += entries.map { |g, a, v| "  require '#{g.tr('.', '/')}/#{a}/#{v}/#{a}-#{v}.jar'" }
+  lines += jars.map { |j| "  require '#{jar_require_path(j)}'" }
   lines += ['end', '', 'if defined? Jars']
-  lines += entries.map { |g, a, v| "  require_jar '#{g}', '#{a}', '#{v}'" }
+  lines += jars.map { |j| "  require_jar #{j.gacv.map { |c| "'#{c}'" }.join(', ')}" }
   lines << 'end'
   File.write(File.join(vendor, 'neo4j-ruby-driver_jars.rb'), "#{lines.join("\n")}\n")
+end
+
+# Load-path-relative require target for a vendored jar. Mirrors
+# Jars::JarDetails#path (whose own path is absolute, under Jars.home) but keeps
+# it relative to lib/, since the plain-require fallback loads off $LOAD_PATH.
+def jar_require_path(jar)
+  File.join(jar.group_id.tr('.', '/'), jar.artifact_id, jar.version,
+            "#{jar.gacv[1..].join('-')}.jar")
+end
+
+# JRuby only (no-op otherwise): regenerate the vendored jars + Jars.lock, then
+# stage Jars.lock into the gem root so the published gem pins exact versions.
+def prepare_jruby_jars(impl, root, stage)
+  return unless impl == 'jruby'
+
+  regenerate_jruby_jars(root)
+  FileUtils.cp(File.join(root, 'Jars.lock'), stage)
 end
 
 # Pattern 1 staged build (see JRUBY.md): copy lib/shared/ and lib/<impl>/
@@ -57,21 +78,16 @@ def stage_and_build(impl)
   FileUtils.rm_rf(stage)
   FileUtils.mkdir_p(File.join(stage, 'lib'))
   FileUtils.cp_r(File.join(root, 'lib/shared/.'), File.join(stage, 'lib'))
-  # JRuby: resolve + vendor the Java-driver jars, and regenerate Jars.lock and
-  # the require manifest, so the staged copy below is deterministic on a clean
-  # checkout rather than a side effect of a prior `bundle install`.
-  regenerate_jruby_jars(root) if impl == 'jruby'
+  # JRuby only (no-op for MRI): (re)generate + stage the vendored jars before
+  # the lib/jruby copy, so the staged tree is deterministic on a clean checkout
+  # rather than a side effect of a prior `bundle install`.
+  prepare_jruby_jars(impl, root, stage)
   FileUtils.cp_r(File.join(root, "lib/#{impl}/."), File.join(stage, 'lib'))
   FileUtils.mkdir_p(File.join(stage, 'build'))
   FileUtils.cp(File.join(root, 'build/gemspec_common.rb'), File.join(stage, 'build'))
   [gemspec_file, 'README.md', 'LICENSE.txt'].each do |f|
     src = File.join(root, f)
     FileUtils.cp(src, stage) if File.exist?(src)
-  end
-  # JRuby: ship Jars.lock alongside the vendored jars so the published gem pins
-  # exact versions and needs no Maven at install time.
-  if impl == 'jruby' && File.exist?(File.join(root, 'Jars.lock'))
-    FileUtils.cp(File.join(root, 'Jars.lock'), stage)
   end
 
   # Run `gem build` outside Bundler. If we leave Bundler env in place, the

--- a/neo4j-ruby-driver-java.gemspec
+++ b/neo4j-ruby-driver-java.gemspec
@@ -6,9 +6,25 @@ Gem::Specification.new do |spec|
   spec.platform = 'java'
   common_gemspec(spec, 'jruby')
   spec.add_dependency 'jar-dependencies', '>= 0.5.5'
-  spec.add_development_dependency 'ruby-maven', '>= 0'
-  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-all, 6.2.1'
-  spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-observation-metrics, 6.2.1'
-  # spec.requirements << 'jar org.neo4j.bolt, neo4j-bolt-connection-pooled, 10.1.0'
+
+  if ENV['STAGED_BUILD'] == '1'
+    # Published gem: the jars are vendored into lib/ and pinned by Jars.lock.
+    # Declaring NO `requirements` here is deliberate — jar-dependencies' post
+    # install hook only runs Maven when `jars?` is true, i.e. requirements are
+    # present AND jar-dependencies is a runtime dep (see Jars::Installer#jars?).
+    # With no requirements the hook is a no-op, so `gem install` does ZERO Maven
+    # / network — the vendored jars load via neo4j-ruby-driver_jars.rb.
+    #
+    # Ship Jars.lock (JRuby-only) so the published gem pins exact jar versions.
+    # (common_gemspec set spec.files for the shared lib/ tree; this appends the
+    # jruby-specific lockfile without leaking it into the shared gemspec.)
+    spec.files += Dir['Jars.lock']
+  else
+    # Dev tree: resolve + vendor the jars from Maven (writes Jars.lock and the
+    # vendored tree that the staged build then packages).
+    spec.add_development_dependency 'ruby-maven', '>= 0'
+    spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-all, 6.2.1'
+    spec.requirements << 'jar org.neo4j.driver, neo4j-java-driver-observation-metrics, 6.2.1'
+  end
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## Problem

The `java`-platform gem had drifted into the **worst of both** `jar-dependencies` models:

- The jars were **vendored** (incidentally — CI's `bundle install` runs before `rake build:jruby` and populates `lib/jruby`), so the gem is 4.9 MB…
- …**and** `gem install` still ran **Maven**, because `Jars::Installer#jars?` fires the post-install hook whenever the gemspec has non-empty `spec.requirements` **plus** a runtime `jar-dependencies` dep. `Jars.lock` does *not* gate that hook.

Net: a fat gem **and** an install-time Maven round-trip — which errors when `ruby-maven` can't be installed (reproduced on a clean install of the current published gem).

## Change

Make vendoring deliberate and eliminate install-time Maven:

- **java gemspec** omits `spec.requirements` under `STAGED_BUILD=1` → `jars?` is false → **`gem install` does zero Maven / network**. `jar-dependencies` stays a runtime dep so `require_jar` loads the vendored jars. Also ships `Jars.lock` (added here, not in the shared `gemspec_common.rb`).
- **`rake build:jruby`** regenerates deterministically on a clean checkout: `lock_jars --vendor-dir lib/jruby` resolves + vendors + writes `Jars.lock`, then the require manifest (`neo4j-ruby-driver_jars.rb`) is generated **from** `Jars.lock` so it can't drift (the old manifest had gone stale at 6.2.0 while requirements said 6.2.1). Maven runs at **build** time only.
- Vendored jars, `Jars.lock`, and the manifest are all **git-ignored** — build artifacts, never committed.

## Verified

- Clean-checkout build (all jar artifacts wiped) → resolves, vendors, locks, generates manifest, builds gem.
- Published gem: `requirements = []`; contains `Jars.lock` + the three 6.2.1 jars + generated manifest.
- Isolated `gem install` → **0** Maven/download mentions, no error (vs. the current published gem which throws `UnsatisfiableDependencyError: ruby-maven`).
- Runtime loads `org.neo4j.driver.GraphDatabase` from the vendored jar offline.
- MRI gem unaffected: no jars, **0** `Jars.lock`.

## Trade-off

The `java` gem stays ~4.9 MB (the shaded `neo4j-java-driver-all` uber jar). The alternative — a ~114 KB gem that fetches at install — reintroduces the Maven-at-install fragility we already patch around with `BUNDLE_JOBS=1` (the post-install hook races under parallel installs), plus network/air-gapped failures. Reliability over size, matching why nokogiri et al. ship fat platform gems.

Rationale recorded in `DECISIONS.md` (2026-08-13).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JRuby gem packages now include pinned Java driver dependencies, enabling installation and runtime use without Maven downloads.
  * JRuby builds generate deterministic dependency manifests and include the required lockfile.
* **Bug Fixes**
  * Improved consistency and reliability of JRuby packaging by resolving dependencies during the build process.
  * MRI gem packaging remains unchanged.
* **Documentation**
  * Added a decision record documenting the updated JRuby packaging and dependency workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->