### PR TITLE
fix(loader): pre-define namespaces so JRuby load survives SimpleCov 1.1.1

### DIFF
--- a/lib/shared/neo4j-ruby-driver_loader.rb
+++ b/lib/shared/neo4j-ruby-driver_loader.rb
@@ -34,18 +34,23 @@ module Neo4j
           loader.ignore(File.expand_path(__FILE__))
           loader.ignore(File.expand_path('neo4j-ruby-driver.rb', __dir__))
           loader.ignore(File.expand_path('neo4j_ruby_driver.rb', __dir__))
-          predefine_namespaces(loader, [shared_root, impl_root])
+          # JRuby-only workaround (native CRuby is unaffected — see below). Keyed
+          # on the runtime engine, not the flavor, so it also covers mri-on-jruby.
+          predefine_namespaces(loader, [shared_root, impl_root]) if RUBY_ENGINE == 'jruby'
           loader.setup
           loader.eager_load
         end
 
-        # Zeitwerk manages a directory that has no matching file as an *implicit*
-        # namespace, autovivifying the module by requiring the directory itself.
-        # Some require-decorating tools break that interception — notably
-        # SimpleCov 1.1.1 on JRuby — so the bare directory reaches Kernel#require
-        # and raises `LoadError: cannot load such file -- …/<dir>`. Defining each
-        # namespace module up front makes it a normal *explicit* namespace, which
-        # sidesteps the autovivification path entirely.
+        # Work around an upstream SimpleCov 1.1.1 × Zeitwerk bug that only bites on
+        # JRuby (simplecov-ruby/simplecov#1273). Zeitwerk manages a directory with
+        # no matching file as an *implicit* namespace, autovivifying the module by
+        # requiring the directory itself and relying on its Kernel#require
+        # decoration to intercept. When SimpleCov 1.1.1 starts before this loader
+        # eager-loads, it clobbers that interception on JRuby, so the bare
+        # directory reaches Kernel#require and raises
+        # `LoadError: cannot load such file -- …/<dir>`. Defining each namespace
+        # module up front makes it a normal *explicit* namespace, sidestepping the
+        # autovivification path. Remove once the SimpleCov bug is fixed.
         def predefine_namespaces(loader, roots)
           roots.each do |root|
             next unless File.directory?(root)

--- a/lib/shared/neo4j-ruby-driver_loader.rb
+++ b/lib/shared/neo4j-ruby-driver_loader.rb
@@ -34,8 +34,38 @@ module Neo4j
           loader.ignore(File.expand_path(__FILE__))
           loader.ignore(File.expand_path('neo4j-ruby-driver.rb', __dir__))
           loader.ignore(File.expand_path('neo4j_ruby_driver.rb', __dir__))
+          predefine_namespaces(loader, [shared_root, impl_root])
           loader.setup
           loader.eager_load
+        end
+
+        # Zeitwerk manages a directory that has no matching file as an *implicit*
+        # namespace, autovivifying the module by requiring the directory itself.
+        # Some require-decorating tools break that interception — notably
+        # SimpleCov 1.1.1 on JRuby — so the bare directory reaches Kernel#require
+        # and raises `LoadError: cannot load such file -- …/<dir>`. Defining each
+        # namespace module up front makes it a normal *explicit* namespace, which
+        # sidesteps the autovivification path entirely.
+        def predefine_namespaces(loader, roots)
+          roots.each do |root|
+            next unless File.directory?(root)
+
+            Dir.glob('**/', base: root).sort.each do |rel|
+              segments = rel.split('/')
+              next if segments.first == 'org' # vendored jars — ignored by the loader
+
+              segments.inject(Object) do |parent, segment|
+                cname = loader.inflector.camelize(segment, File.join(root, rel)).to_sym
+                find_or_define_module(parent, cname)
+              end
+            end
+          end
+        end
+
+        def find_or_define_module(parent, cname)
+          return parent.const_get(cname, false) if parent.const_defined?(cname, false)
+
+          parent.const_set(cname, Module.new)
         end
 
         def jruby? = @impl == :jruby


### PR DESCRIPTION
## Problem

A consumer (activegraph) hit, only in CI on JRuby:

```
LoadError: cannot load such file -- .../neo4j-ruby-driver-6.2.1.beta.4-java/lib/neo4j/driver/internal
# ./lib/active_graph.rb:19  (require 'neo4j/driver')
```

Root cause (reproduced on jruby-10.1.1.0): Zeitwerk manages a directory with no matching file as an **implicit namespace**, autovivifying the module by *requiring the directory* and relying on its `Kernel#require` decoration to intercept. **SimpleCov 1.1.1** on JRuby breaks that interception, so the bare directory reaches `Kernel#require` → `LoadError`, during the loader's `eager_load` (`internal`, then `ext`, …).

Why it only bit that consumer: their `Gemfile.lock` is git-ignored and `gem 'simplecov'` is unconstrained, so CI resolved **SimpleCov 1.1.1** fresh (a local checkout with an older lock at 0.22.0 loads fine). It is **not** a packaging problem — the `internal/` directory ships correctly — and not caused by the jar-vendoring change.

## Fix

Before `setup`/`eager_load`, walk the managed roots and define a module for every subdirectory, making each an **explicit** namespace. Explicit namespaces don't use the implicit autovivification-via-`require` path, so the fragility is gone. The loader is shared, so this applies to both flavors; MRI behaviour is unchanged.

Whack-a-mole alternatives were ruled out: dropping `eager_load` just moves the failure to the inline `module Internal` reopen; pre-defining one namespace moves it to the next directory (`ext`).

## Verification (jruby-10.1.1.0 + SimpleCov 1.1.1)

- The published-gem repro (`cannot load … /internal`) is **gone**; the rebuilt gem loads clean.
- `GraphDatabase`, `Internal::Deprecator` (shared rb), `Internal::DriverFactory` (java), `Types::UUID`, `Ext::GraphDatabase` all resolve.
- Loads unchanged **without** SimpleCov (no regression).
- **MRI** dev-tree load still resolves `GraphDatabase` / `Internal` / `Types::Point` / `Exceptions::ClientException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JRuby library loading to reliably recognize and initialize nested namespaces during startup.
  * Preserved existing constants while preventing loading issues caused by vendored directories.
  * Improved compatibility with code coverage and automatic loading workflows.

* **Documentation**
  * Added guidance explaining namespace loading behavior and the associated workaround.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Root cause is upstream (SimpleCov 1.1.1), this is a hardening

The underlying defect is a SimpleCov 1.1.1 × Zeitwerk × JRuby interaction: `SimpleCov.start` (1.1.1) installed *before* the loader's `eager_load` runs breaks Zeitwerk's `require` interception, so the implicit-namespace directory-require falls through. Confirmed load-order dependent and version-dependent:

| | Result |
|---|---|
| `SimpleCov.start` → `require 'neo4j/driver'` | LoadError on `.../internal` |
| `require 'neo4j/driver'` → `SimpleCov.start` | OK |
| SimpleCov 0.22.0, either order | OK |

Minimal driver-free repro filed upstream against SimpleCov. This PR makes the driver robust regardless of load order (explicit namespaces don't use the fragile autovivification path), which is also arguably better practice.

## Interim workaround (for consumers on driver versions before this fix)

Either:
- pin `gem 'simplecov', '~> 0.22'`, **or**
- `require 'neo4j/driver'` **before** `SimpleCov.start` in `spec_helper` — note this only works for code you don't need covered (SimpleCov must start before the files you want measured), so load the driver early, not your own app.


---

## Update: scoped to JRuby + upstream issues filed

- **Scoped to JRuby** (`RUBY_ENGINE == 'jruby'`) — verified the bug does **not** reproduce on native CRuby (SimpleCov 1.1.1, either load order), so MRI is untouched. Keyed on the runtime engine (not the flavor) so mri-on-jruby is still covered.
- Verified the guarded, jar-vendored gem loads 3/3 on jruby-10.1.1.0 + SimpleCov 1.1.1 (incl. `GraphDatabase`, `Internal::Deprecator`, `AuthTokenManager`).
- **Upstream, where the real fix belongs:**
  - SimpleCov: simplecov-ruby/simplecov#1273 (the regression — 0.22.0 fine, 1.1.1 broken).
  - Zeitwerk: fxn/zeitwerk#340 (asking whether there's a supported mitigation / where the require-decoration contract lives).

This PR is an **explicitly interim, JRuby-only hardening** — the code comment links #1273 and says to remove it once the SimpleCov bug is fixed. Reviewers who'd rather not carry any workaround can close this and rely on the consumer options above; the trade-off is JRuby consumers stay broken until SimpleCov ships a fix.
