### PR TITLE
test(memgraph): run the shared suite against Memgraph via a memgraph: false tag

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -110,11 +110,13 @@ jobs:
   # flavors — latest CRuby (pure-Ruby Bolt) and latest JRuby (Java driver, which
   # Memgraph officially supports). See docs/memgraph.md.
   rspec-memgraph:
-    name: rspec (memgraph / ruby ${{ matrix.ruby }})
+    name: rspec (memgraph / ruby ${{ matrix.ruby }}${{ matrix.force_mri && ' [mri flavor]' || '' }})
     runs-on: ubuntu-latest
-    # Both flavors pass the same tagged suite against Memgraph. The JRuby leg is
-    # kept non-blocking only to match the repo-wide JRuby policy (see the rspec
-    # job above); the CRuby leg is the gating one.
+    # Only the CRuby leg gates. Both JRuby legs (Java-driver flavor, and the
+    # MRI-flavor-on-JVM cross-flavor row) are non-blocking, matching the repo-wide
+    # JRuby policy. The mri-flavor-on-JVM row isolates whether a JRuby-only red is
+    # the Java driver's behavior (MRI-on-JVM passes) or a JVM/Linux environment
+    # effect (MRI-on-JVM fails too) — the same three-cell layout as the Neo4j job.
     continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
 
     strategy:
@@ -123,6 +125,12 @@ jobs:
         ruby:
           - "4.0" # latest CRuby — MRI pure-Ruby Bolt flavor
           - "jruby-10.1.0.0" # latest JRuby — Java-driver flavor
+        force_mri: [false]
+        include:
+          # MRI flavor on JRuby — same env/platform as the Java-driver row but the
+          # pure-Ruby impl, via NEO4J_DRIVER_FORCE_MRI=1 (the Gemfile's flip).
+          - ruby: "jruby-10.1.0.0"
+            force_mri: true
 
     services:
       memgraph:
@@ -144,6 +152,9 @@ jobs:
       TEST_NEO4J_DATABASE: memgraph # Memgraph's default database (no `neo4j` db)
       # Memgraph advertises Neo4j/v5.11.0 compatibility; feeds version-gated specs.
       NEO4J_VERSION: 5.11.0
+      # '1' on the mri-flavor-on-JVM row; empty otherwise. The Gemfile pins to the
+      # MRI gemspec when set (same as the rspec job's cross-flavor row).
+      NEO4J_DRIVER_FORCE_MRI: ${{ matrix.force_mri && '1' || '' }}
       BUNDLE_JOBS: '1'
 
     steps:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -106,12 +106,23 @@ jobs:
 
   # Memgraph compatibility: the SAME shared suite, run against Memgraph instead
   # of Neo4j. Neo4j-only specs are tagged `memgraph: false` and skipped via
-  # TEST_MEMGRAPH (see spec_helper); everything else runs unchanged. MRI flavor
-  # only — the pure-Ruby Bolt impl is the direct wire-compatibility test.
-  # See docs/memgraph.md.
+  # TEST_MEMGRAPH (see spec_helper); everything else runs unchanged. Runs on both
+  # flavors — latest CRuby (pure-Ruby Bolt) and latest JRuby (Java driver, which
+  # Memgraph officially supports). See docs/memgraph.md.
   rspec-memgraph:
-    name: rspec (memgraph)
+    name: rspec (memgraph / ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
+    # Both flavors pass the same tagged suite against Memgraph. The JRuby leg is
+    # kept non-blocking only to match the repo-wide JRuby policy (see the rspec
+    # job above); the CRuby leg is the gating one.
+    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "4.0" # latest CRuby — MRI pure-Ruby Bolt flavor
+          - "jruby-10.1.0.0" # latest JRuby — Java-driver flavor
 
     services:
       memgraph:
@@ -133,7 +144,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4' # MRI flavor (pure-Ruby Bolt)
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Wait for Bolt
         run: |

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -104,6 +104,47 @@ jobs:
       - name: Run RSpec
         run: bundle exec rspec --format progress
 
+  # Memgraph compatibility: the SAME shared suite, run against Memgraph instead
+  # of Neo4j. Neo4j-only specs are tagged `memgraph: false` and skipped via
+  # TEST_MEMGRAPH (see spec_helper); everything else runs unchanged. MRI flavor
+  # only — the pure-Ruby Bolt impl is the direct wire-compatibility test.
+  # See docs/memgraph.md.
+  rspec-memgraph:
+    name: rspec (memgraph)
+    runs-on: ubuntu-latest
+
+    services:
+      memgraph:
+        image: memgraph/memgraph:latest # pin a version once stabilised
+        ports:
+          - 7687:7687
+        # Memgraph has no built-in Docker healthcheck; the step below waits.
+
+    env:
+      TEST_NEO4J_URL: bolt://localhost:7687
+      TEST_MEMGRAPH: "1" # activates the `memgraph: false` exclusion
+      TEST_NEO4J_AUTH: none # Memgraph runs with auth disabled by default
+      TEST_NEO4J_DATABASE: memgraph # Memgraph's default database (no `neo4j` db)
+      # Memgraph advertises Neo4j/v5.11.0 compatibility; feeds version-gated specs.
+      NEO4J_VERSION: 5.11.0
+      BUNDLE_JOBS: '1'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4' # MRI flavor (pure-Ruby Bolt)
+          bundler-cache: true
+      - name: Wait for Bolt
+        run: |
+          for i in $(seq 1 30); do
+            (echo > /dev/tcp/localhost/7687) >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "::error::Memgraph bolt port never opened"; exit 1
+      - name: Run RSpec (Memgraph)
+        run: bundle exec rspec --format progress
+
   # Stable, version-free gate for branch protection. Requiring the matrix
   # legs directly would embed the Ruby/Neo4j versions in the required-check
   # names, so bumping the matrix would silently strip the requirement. This
@@ -118,4 +159,19 @@ jobs:
         if: ${{ needs.rspec.result != 'success' }}
         run: |
           echo "rspec matrix result: ${{ needs.rspec.result }}"
+          exit 1
+
+  # Version-free gate for the Memgraph leg. Not yet added to the branch-protection
+  # ruleset (Memgraph is community-verified, not gating) — promote by requiring
+  # `memgraph-success` once it has been stable for a while.
+  memgraph-success:
+    name: memgraph-success
+    needs: [rspec-memgraph]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the Memgraph suite to pass
+        if: ${{ needs.rspec-memgraph.result != 'success' }}
+        run: |
+          echo "rspec-memgraph result: ${{ needs.rspec-memgraph.result }}"
           exit 1

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -126,10 +126,17 @@ jobs:
 
     services:
       memgraph:
-        image: memgraph/memgraph:latest # pin a version once stabilised
+        image: memgraph/memgraph:3.12.0 # pinned to the validated version
         ports:
           - 7687:7687
-        # Memgraph has no built-in Docker healthcheck; the step below waits.
+        # MEMGRAPH_USER/PASSWORD create the user at startup, which turns auth on
+        # (Memgraph has no auth flag — the first user is the switch). The suite
+        # then authenticates with basic neo4j/password (the driver_helper default),
+        # exercising the auth path the same way as against Neo4j. Memgraph has no
+        # built-in Docker healthcheck; the query-ready step below waits.
+        env:
+          MEMGRAPH_USER: neo4j
+          MEMGRAPH_PASSWORD: password
 
     env:
       TEST_NEO4J_URL: bolt://localhost:7687
@@ -141,26 +148,22 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false # no authenticated git ops here; don't leak the token to bundle
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Wait for Bolt
+      - name: Wait for Memgraph (query-ready)
+        # A listening TCP port doesn't mean Memgraph accepts queries yet (and the
+        # startup user may not exist yet); retry a real authenticated query until
+        # it responds.
         run: |
           for i in $(seq 1 30); do
-            (echo > /dev/tcp/localhost/7687) >/dev/null 2>&1 && exit 0
+            bundle exec ruby -e "require 'neo4j/driver'; Neo4j::Driver::GraphDatabase.driver('bolt://localhost:7687', Neo4j::Driver::AuthTokens.basic('neo4j', 'password')) { |d| d.session { |s| s.run('RETURN 1').consume } }" >/dev/null 2>&1 && exit 0
             sleep 2
           done
-          echo "::error::Memgraph bolt port never opened"; exit 1
-      - name: Enable Memgraph auth (create the neo4j user)
-        # Memgraph starts with auth open; creating a user turns it on. We connect
-        # once with AuthTokens.none (allowed while no users exist), then the suite
-        # authenticates with basic neo4j/password (the driver_helper default), so
-        # the auth path is exercised the same way as against Neo4j.
-        run: >-
-          bundle exec ruby -e "require 'neo4j/driver';
-          Neo4j::Driver::GraphDatabase.driver('bolt://localhost:7687', Neo4j::Driver::AuthTokens.none) { |d|
-          d.session { |s| s.run(%q(CREATE USER neo4j IDENTIFIED BY 'password')).consume } }"
+          echo "::error::Memgraph never became query-ready"; exit 1
       - name: Run RSpec (Memgraph)
         run: bundle exec rspec --format progress
 

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -134,7 +134,6 @@ jobs:
     env:
       TEST_NEO4J_URL: bolt://localhost:7687
       TEST_MEMGRAPH: "1" # activates the `memgraph: false` exclusion
-      TEST_NEO4J_AUTH: none # Memgraph runs with auth disabled by default
       TEST_NEO4J_DATABASE: memgraph # Memgraph's default database (no `neo4j` db)
       # Memgraph advertises Neo4j/v5.11.0 compatibility; feeds version-gated specs.
       NEO4J_VERSION: 5.11.0
@@ -153,6 +152,15 @@ jobs:
             sleep 2
           done
           echo "::error::Memgraph bolt port never opened"; exit 1
+      - name: Enable Memgraph auth (create the neo4j user)
+        # Memgraph starts with auth open; creating a user turns it on. We connect
+        # once with AuthTokens.none (allowed while no users exist), then the suite
+        # authenticates with basic neo4j/password (the driver_helper default), so
+        # the auth path is exercised the same way as against Neo4j.
+        run: >-
+          bundle exec ruby -e "require 'neo4j/driver';
+          Neo4j::Driver::GraphDatabase.driver('bolt://localhost:7687', Neo4j::Driver::AuthTokens.none) { |d|
+          d.session { |s| s.run(%q(CREATE USER neo4j IDENTIFIED BY 'password')).consume } }"
       - name: Run RSpec (Memgraph)
         run: bundle exec rspec --format progress
 

--- a/docs/memgraph.md
+++ b/docs/memgraph.md
@@ -62,71 +62,65 @@ Do **not** pass `database: 'neo4j'` — Memgraph's default database is named
 These are all detected cleanly — a clear exception, or a benign empty result —
 so application code fails fast rather than silently misbehaving.
 
-## Continuous integration (sketch)
+## How it's tested
 
-Because the full `spec/shared/integration/` suite includes Neo4j-specific
-behaviour (routing, bookmarks, multi-database, byte parameters), a Memgraph lane
-should run a **curated compatibility subset**, not the whole suite. Two moving
-parts:
+Memgraph is treated as **another target of the existing shared suite** — the same
+way that suite already runs against the MRI and JRuby flavors — rather than a
+parallel set of Memgraph-specific specs. The whole `spec/shared/**` suite runs
+against Memgraph unchanged; the handful of examples that assert Neo4j-only
+behaviour are tagged and skipped.
 
-**1. A dedicated compatibility spec** — `spec/memgraph/compatibility_spec.rb` —
-covering the "works out of the box" matrix and asserting the gaps behave as
-documented (e.g. `neo4j://` raises `ServiceUnavailableException`, bookmarks are
-empty). It connects with Memgraph-appropriate config (`bolt://`,
-`AuthTokens.none`, no hardcoded database) rather than reusing the Neo4j
-`spec_helper` defaults.
+**The `memgraph: false` tag.** Examples exercising a documented gap carry
+`memgraph: false` metadata with a one-line reason, e.g.:
 
-**2. A workflow** — `.github/workflows/memgraph.yml` — non-gating at first
-(informational, like other incubating lanes), promoted to required once green:
-
-```yaml
-name: Memgraph compatibility
-
-on:
-  push:
-    branches: [main]
-    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
-  pull_request:
-    paths-ignore: ['**/*.md', 'lib/shared/neo4j/driver/version.rb']
-
-jobs:
-  memgraph:
-    name: memgraph-compat
-    runs-on: ubuntu-latest
-    services:
-      memgraph:
-        image: memgraph/memgraph:latest        # pin a version once stabilised
-        ports:
-          - 7687:7687
-        # Memgraph has no built-in Docker healthcheck; the step below waits.
-
-    env:
-      TEST_MEMGRAPH_URL: bolt://localhost:7687
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.4'                   # MRI flavor (pure-Ruby Bolt)
-          bundler-cache: true
-      - name: Wait for Bolt
-        run: |
-          for i in $(seq 1 30); do
-            (echo > /dev/tcp/localhost/7687) >/dev/null 2>&1 && exit 0
-            sleep 2
-          done
-          echo "::error::Memgraph bolt port never opened"; exit 1
-      - name: Run Memgraph compatibility spec
-        run: bundle exec rspec spec/memgraph
+```ruby
+context 'when bytes', memgraph: false do # Memgraph has no Bolt byte-array type
 ```
+
+`spec/spec_helper.rb` excludes them only when the suite targets Memgraph
+(`config.filter_run_excluding memgraph: false if memgraph?`), mirroring the
+existing `auth: :none` / `csv:` conditional excludes. Against Neo4j the tag is
+inert — every example still runs. Currently **465 of 572** shared examples run
+against Memgraph; the ~107 tagged ones cover the gaps in the table above (error
+mapping to base `Neo4jException`, routing, bookmarks, multi-database, byte
+params, duration/temporal normalization, summary/plan/profile shape, auth).
+
+**Connecting the suite to Memgraph** is env-driven (`spec/shared/support/driver_helper.rb`):
+
+| Env var | Value | Why |
+|---|---|---|
+| `TEST_MEMGRAPH` | `1` | Activates the `memgraph: false` exclusion |
+| `TEST_NEO4J_AUTH` | `none` | Memgraph runs with auth disabled → `AuthTokens.none` |
+| `TEST_NEO4J_DATABASE` | `memgraph` | Memgraph's default database (there is no `neo4j` db) |
+| `NEO4J_VERSION` | `5.11.0` | Memgraph's advertised Neo4j-compat level; feeds version-gated specs |
+
+Run it locally against a Memgraph container:
+
+```bash
+docker run -d -p 7687:7687 memgraph/memgraph
+TEST_MEMGRAPH=1 TEST_NEO4J_AUTH=none TEST_NEO4J_DATABASE=memgraph \
+  NEO4J_VERSION=5.11.0 bundle exec rspec
+```
+
+## Continuous integration
+
+The Memgraph leg is a job in `.github/workflows/specs.yml` — the *same* workflow
+and the *same* `bundle exec rspec` invocation as the Neo4j matrix, just pointed at
+a Memgraph service container with the env vars above:
+
+- **`rspec-memgraph`** starts a `memgraph/memgraph` service container, waits for
+  the Bolt port, and runs `bundle exec rspec` with `TEST_MEMGRAPH=1` (+ auth-none,
+  `memgraph` database). No separate spec file, no separate workflow — it reuses the
+  entire shared suite.
+- **`memgraph-success`** is a version-free aggregator gate (mirroring
+  `rspec-success`) so the branch-protection ruleset can require a stable name that
+  doesn't embed the Memgraph image version.
 
 Notes:
 
 - **MRI flavor only** to start — it's the pure-Ruby Bolt implementation, so it's
-  the direct test of wire compatibility. Add a JRuby leg later to cover the
-  Java-driver path.
-- **Version-stable gate.** If this becomes a required check, add a
-  `memgraph-success` aggregator job (see `specs.yml`) so the ruleset requires a
-  name that doesn't embed the Memgraph version.
+  the direct test of wire compatibility. A JRuby leg (Java-driver path) can follow.
+- **Non-gating until promoted.** `memgraph-success` is not yet in the ruleset;
+  require it once the lane has been stable for a while.
 - **Pin the image** (`memgraph/memgraph:<version>`) once the baseline is
   established, so a Memgraph release can't silently change the result.

--- a/docs/memgraph.md
+++ b/docs/memgraph.md
@@ -89,7 +89,7 @@ context 'when bytes', memgraph: false do # Memgraph has no Bolt byte-array type
 `spec/spec_helper.rb` excludes them only when the suite targets Memgraph
 (`config.filter_run_excluding memgraph: false if memgraph?`), mirroring the
 existing `auth: :none` / `csv:` conditional excludes. Against Neo4j the tag is
-inert — every example still runs. Currently **~478 of ~578** shared examples run
+inert — every example still runs. Currently **~477 of ~578** shared examples run
 against Memgraph — **identically on both flavors** (MRI and JRuby); the ~100
 tagged ones cover the gaps in the table above (routing, bookmarks, multi-database,
 byte params, duration/temporal precision, summary/plan/profile shape, auth) plus
@@ -116,16 +116,13 @@ Memgraph error, and the tagged set is identical on MRI and JRuby.
 
 The suite runs **with authentication on** (basic `neo4j`/`password`, the
 `driver_helper` default) so the auth path is exercised the same way as against
-Neo4j. Since Memgraph enables auth only once a user exists, a one-shot bootstrap
-creates that user before the suite runs — connecting with `AuthTokens.none` while
-the instance is still open:
+Neo4j. Memgraph enables auth as soon as a user exists, and the `MEMGRAPH_USER` /
+`MEMGRAPH_PASSWORD` env vars create that user at startup — so the container comes
+up with auth already on:
 
 ```bash
-docker run -d -p 7687:7687 memgraph/memgraph
-# Create the user (turns auth on for the whole instance):
-bundle exec ruby -e "require 'neo4j/driver'; \
-  Neo4j::Driver::GraphDatabase.driver('bolt://localhost:7687', Neo4j::Driver::AuthTokens.none) { |d| \
-    d.session { |s| s.run(%q(CREATE USER neo4j IDENTIFIED BY 'password')).consume } }"
+docker run -d -p 7687:7687 \
+  -e MEMGRAPH_USER=neo4j -e MEMGRAPH_PASSWORD=password memgraph/memgraph:3.12.0
 TEST_MEMGRAPH=1 TEST_NEO4J_DATABASE=memgraph NEO4J_VERSION=5.11.0 bundle exec rspec
 ```
 
@@ -135,21 +132,26 @@ The Memgraph leg is a job in `.github/workflows/specs.yml` — the *same* workfl
 and the *same* `bundle exec rspec` invocation as the Neo4j matrix, just pointed at
 a Memgraph service container with the env vars above:
 
-- **`rspec-memgraph`** starts a `memgraph/memgraph` service container, waits for
-  the Bolt port, creates the `neo4j` user (enabling auth), and runs `bundle exec
-  rspec` with `TEST_MEMGRAPH=1` (+ `memgraph` database, basic auth). No separate
-  spec file, no separate workflow — it reuses the
-  entire shared suite. It runs as a **matrix over both flavors**: latest CRuby
-  (MRI pure-Ruby Bolt) and latest JRuby (Java driver).
+- **`rspec-memgraph`** starts a pinned `memgraph/memgraph:3.12.0` service
+  container (with `MEMGRAPH_USER`/`MEMGRAPH_PASSWORD` set, so it comes up with auth
+  on), waits until Memgraph is query-ready, and runs `bundle exec rspec` with
+  `TEST_MEMGRAPH=1` (+ `memgraph` database, basic auth). No separate spec file, no
+  separate workflow — it reuses the entire shared suite. It runs as a **matrix
+  over both flavors**: latest CRuby (MRI pure-Ruby Bolt) and latest JRuby (Java
+  driver).
 - **`memgraph-success`** is a version-free aggregator gate (mirroring
   `rspec-success`) so the branch-protection ruleset can require a stable name that
   doesn't embed the Memgraph image version.
 
 Notes:
 
-- **Both flavors pass** the same tagged suite. The CRuby leg gates; the JRuby leg
-  is kept non-blocking only to match the repo-wide JRuby policy.
+- **CRuby leg is fully green and gates.** The JRuby leg is non-blocking and shows
+  **two** tests red — the Java driver's connection **re-auth** (`verify_authentication`)
+  and its handling of a **cancelled failing stream** behave differently against
+  Memgraph than the pure-Ruby impl does (both pass on CRuby+Memgraph and on both
+  flavors against Neo4j). These reflect the Java driver's own behavior, which we
+  don't override, so they're left as known JRuby×Memgraph differences.
 - **Non-gating until promoted.** `memgraph-success` is not yet in the ruleset;
   require it once the lane has been stable for a while.
-- **Pin the image** (`memgraph/memgraph:<version>`) once the baseline is
-  established, so a Memgraph release can't silently change the result.
+- **Image is pinned** to `memgraph/memgraph:3.12.0` so a Memgraph release can't
+  silently change the result; bump it deliberately after re-validating.

--- a/docs/memgraph.md
+++ b/docs/memgraph.md
@@ -7,11 +7,10 @@ connection **with no code changes** — the gaps below are Memgraph feature/dial
 differences, not driver bugs, and the driver degrades gracefully on all of them.
 
 > Status: **community-verified, not officially supported.** Measured against
-> **Memgraph v3.12.0** with the MRI (pure-Ruby Bolt) flavor. Memgraph advertises
-> itself as *"Neo4j/v5.11.0 compatible"* and this driver negotiates **Bolt 5.x**
-> with it. The JRuby flavor wraps the Neo4j Java driver, which Memgraph
-> officially supports, so it is expected to behave the same (confirm before
-> relying on it).
+> **Memgraph v3.12.0** on **both flavors** — MRI (pure-Ruby Bolt) and JRuby
+> (Neo4j Java driver, which Memgraph officially supports). The same tagged suite
+> passes identically on each. Memgraph advertises itself as *"Neo4j/v5.11.0
+> compatible"* and this driver negotiates **Bolt 5.x** with it.
 
 ## Connecting
 
@@ -42,9 +41,9 @@ Do **not** pass `database: 'neo4j'` — Memgraph's default database is named
 | Bolt version negotiation | ✓ (Bolt 5.x) |
 | Scalars, parameters (Integer/String/Float/List/Map), `UNWIND` | ✓ |
 | Nodes, relationships, paths, labels | ✓ |
-| Temporal read **and** parameter round-trip — `Date`, `LocalDateTime`, zoned `DateTime`, `Duration` | ✓ |
+| Temporal read **and** parameter round-trip — `Date`, `LocalDateTime`, zoned `DateTime`, `Duration` | ✓ (µs precision — see gaps) |
 | `Types::Point` (2D) read and round-trip | ✓ |
-| `Types::Duration` parameter round-trip | ✓ (value-exact) |
+| `Types::Duration` parameter round-trip | ✓ (value-exact to µs) |
 | Explicit transactions (`begin_transaction`) | ✓ |
 | Managed transactions (`execute_read` / `execute_write`, with retry) | ✓ |
 | `CALL dbms.components()` | ✓ (Memgraph implements it) |
@@ -58,9 +57,13 @@ Do **not** pass `database: 'neo4j'` — Memgraph's default database is named
 | **Bookmarks** | `session.last_bookmarks` returns an empty set after commit | Memgraph has no causal-consistency bookmarks. The driver returns an empty set (not an error) — safe to ignore. |
 | **Byte-array parameters** | Memgraph errors when a `String` with `BINARY` (`.b`) encoding is sent as a parameter | Memgraph has no blob type on the Bolt wire. Avoid byte parameters. |
 | **`duration()` with months** | `duration('P1M…')` → *Invalid duration string* | Cypher-dialect difference: Memgraph durations are day/time only (no month component). Month-less strings and the Bolt `Duration` struct (`months = 0`) work fine. |
+| **Temporal precision** | A `Time`/`DateTime`/`Duration` carrying **sub-microsecond nanoseconds** comes back with the last three digits zeroed (e.g. `…123456789` → `…123456000`) | Memgraph stores temporal values at **microsecond** resolution; Neo4j keeps full **nanosecond** resolution. Values round-trip exactly at µs precision; only the sub-µs remainder is lost. Memgraph's parser also rejects nanosecond-precision string literals (`localtime('12:00:00.123456789')` → *Extra characters…*). |
+| **`datetime({epochMillis: …})`** | Memgraph's `datetime()` has no `epochMillis` / `epochSeconds` / `nanosecond` construction keys | Construct from an ISO string or the Bolt temporal struct instead. |
+| **Single-digit date components** | `localdatetime('2018-1-1T…')` → parse error | Memgraph requires zero-padded `YYYY-MM-DD`; Neo4j is lenient. Zero-pad and it works on both. |
 
-These are all detected cleanly — a clear exception, or a benign empty result —
-so application code fails fast rather than silently misbehaving.
+These are all detected cleanly — a clear exception, a benign empty result, or a
+documented precision truncation — so application code fails fast (or degrades
+predictably) rather than silently misbehaving.
 
 ## How it's tested
 
@@ -80,10 +83,14 @@ context 'when bytes', memgraph: false do # Memgraph has no Bolt byte-array type
 `spec/spec_helper.rb` excludes them only when the suite targets Memgraph
 (`config.filter_run_excluding memgraph: false if memgraph?`), mirroring the
 existing `auth: :none` / `csv:` conditional excludes. Against Neo4j the tag is
-inert — every example still runs. Currently **465 of 572** shared examples run
-against Memgraph; the ~107 tagged ones cover the gaps in the table above (error
-mapping to base `Neo4jException`, routing, bookmarks, multi-database, byte
-params, duration/temporal normalization, summary/plan/profile shape, auth).
+inert — every example still runs. Currently **~468 of ~578** shared examples run
+against Memgraph — identically on **both flavors** (MRI and JRuby); the ~110
+tagged ones cover the gaps in the table above (error mapping to base
+`Neo4jException`, routing, bookmarks, multi-database, byte params,
+duration/temporal precision, summary/plan/profile shape, auth). Where a gap is a
+format artifact rather than a hard limitation (single-digit dates, sub-µs
+precision), the tagged example keeps a parallel that *does* run on Memgraph, so
+coverage isn't simply dropped.
 
 **Connecting the suite to Memgraph** is env-driven (`spec/shared/support/driver_helper.rb`):
 
@@ -111,15 +118,16 @@ a Memgraph service container with the env vars above:
 - **`rspec-memgraph`** starts a `memgraph/memgraph` service container, waits for
   the Bolt port, and runs `bundle exec rspec` with `TEST_MEMGRAPH=1` (+ auth-none,
   `memgraph` database). No separate spec file, no separate workflow — it reuses the
-  entire shared suite.
+  entire shared suite. It runs as a **matrix over both flavors**: latest CRuby
+  (MRI pure-Ruby Bolt) and latest JRuby (Java driver).
 - **`memgraph-success`** is a version-free aggregator gate (mirroring
   `rspec-success`) so the branch-protection ruleset can require a stable name that
   doesn't embed the Memgraph image version.
 
 Notes:
 
-- **MRI flavor only** to start — it's the pure-Ruby Bolt implementation, so it's
-  the direct test of wire compatibility. A JRuby leg (Java-driver path) can follow.
+- **Both flavors pass** the same tagged suite. The CRuby leg gates; the JRuby leg
+  is kept non-blocking only to match the repo-wide JRuby policy.
 - **Non-gating until promoted.** `memgraph-success` is not yet in the ruleset;
   require it once the lane has been stable for a while.
 - **Pin the image** (`memgraph/memgraph:<version>`) once the baseline is

--- a/docs/memgraph.md
+++ b/docs/memgraph.md
@@ -136,21 +136,26 @@ a Memgraph service container with the env vars above:
   container (with `MEMGRAPH_USER`/`MEMGRAPH_PASSWORD` set, so it comes up with auth
   on), waits until Memgraph is query-ready, and runs `bundle exec rspec` with
   `TEST_MEMGRAPH=1` (+ `memgraph` database, basic auth). No separate spec file, no
-  separate workflow — it reuses the entire shared suite. It runs as a **matrix
-  over both flavors**: latest CRuby (MRI pure-Ruby Bolt) and latest JRuby (Java
-  driver).
+  separate workflow — it reuses the entire shared suite. It runs as a **three-cell
+  matrix**: MRI on CRuby (gating), MRI on the JVM (`NEO4J_DRIVER_FORCE_MRI=1`), and
+  the JRuby/Java-driver flavor — the same layout as the Neo4j job. The MRI-on-JVM
+  cell shares the Java-driver row's platform, so it isolates flavor from
+  environment (see the note below).
 - **`memgraph-success`** is a version-free aggregator gate (mirroring
   `rspec-success`) so the branch-protection ruleset can require a stable name that
   doesn't embed the Memgraph image version.
 
 Notes:
 
-- **CRuby leg is fully green and gates.** The JRuby leg is non-blocking and shows
-  **two** tests red — the Java driver's connection **re-auth** (`verify_authentication`)
-  and its handling of a **cancelled failing stream** behave differently against
-  Memgraph than the pure-Ruby impl does (both pass on CRuby+Memgraph and on both
-  flavors against Neo4j). These reflect the Java driver's own behavior, which we
-  don't override, so they're left as known JRuby×Memgraph differences.
+- **Two tests are Java-driver-flavor-specific.** The Java driver's connection
+  **re-auth** (`verify_authentication`) and its handling of a **cancelled failing
+  stream** fail *only* on the JRuby/Java-driver flavor against Memgraph on Linux
+  CI. The three-cell matrix isolates the cause: **MRI passes on both CRuby and the
+  JVM** (`force_mri`) — same platform as the Java-driver row — so this is the Java
+  driver's own behavior, **not** a JVM/Linux environment effect and **not** an MRI
+  gap. We don't override the Java driver, so those two carry `memgraph_jruby: false`
+  — excluded only on that flavor (`memgraph? && Loader.jruby?`), leaving the other
+  three cells (MRI-CRuby, MRI-on-JVM, and all Neo4j) running them.
 - **Non-gating until promoted.** `memgraph-success` is not yet in the ruleset;
   require it once the lane has been stable for a while.
 - **Image is pinned** to `memgraph/memgraph:3.12.0` so a Memgraph release can't

--- a/docs/memgraph.md
+++ b/docs/memgraph.md
@@ -83,14 +83,22 @@ context 'when bytes', memgraph: false do # Memgraph has no Bolt byte-array type
 `spec/spec_helper.rb` excludes them only when the suite targets Memgraph
 (`config.filter_run_excluding memgraph: false if memgraph?`), mirroring the
 existing `auth: :none` / `csv:` conditional excludes. Against Neo4j the tag is
-inert — every example still runs. Currently **~468 of ~578** shared examples run
-against Memgraph — identically on **both flavors** (MRI and JRuby); the ~110
-tagged ones cover the gaps in the table above (error mapping to base
-`Neo4jException`, routing, bookmarks, multi-database, byte params,
-duration/temporal precision, summary/plan/profile shape, auth). Where a gap is a
-format artifact rather than a hard limitation (single-digit dates, sub-µs
-precision), the tagged example keeps a parallel that *does* run on Memgraph, so
-coverage isn't simply dropped.
+inert — every example still runs. Currently **~478 of ~578** shared examples run
+against Memgraph — **identically on both flavors** (MRI and JRuby); the ~100
+tagged ones cover the gaps in the table above (routing, bookmarks, multi-database,
+byte params, duration/temporal precision, summary/plan/profile shape, auth) plus
+error-*text* differences: Memgraph's error **class** matches Neo4j's (see below),
+but its message/code strings differ, so assertions like `raise_error(…, "/ by
+zero")` don't hold. Where a gap is a format artifact rather than a hard limitation
+(single-digit dates, sub-µs precision), the tagged example keeps a parallel that
+*does* run on Memgraph, so coverage isn't simply dropped.
+
+**Error-class parity.** Memgraph sends its own status codes (e.g.
+`Memgraph.ClientError.MemgraphError`). The MRI driver classifies an error by its
+**classification segment** — the second dotted part — matching the Java driver's
+`ErrorUtil`, rather than requiring a literal `Neo.` prefix. So both flavors raise
+the same `ClientException` / `TransientException` / `DatabaseException` for a given
+Memgraph error, and the tagged set is identical on MRI and JRuby.
 
 **Connecting the suite to Memgraph** is env-driven (`spec/shared/support/driver_helper.rb`):
 

--- a/docs/memgraph.md
+++ b/docs/memgraph.md
@@ -33,6 +33,12 @@ end
 Do **not** pass `database: 'neo4j'` — Memgraph's default database is named
 `memgraph`. Omit the database entirely, or pass `database: 'memgraph'`.
 
+Memgraph's auth model has no explicit on/off switch: a fresh instance has **no
+users and open access**, and creating the **first** user (`CREATE USER … IDENTIFIED
+BY …`) flips the whole instance to **mandatory authentication for everyone**. Once
+any user exists, use `AuthTokens.basic(user, pass)` — `AuthTokens.none` is then
+rejected.
+
 ## What works out of the box (`bolt://`)
 
 | Capability | Status |
@@ -105,16 +111,22 @@ Memgraph error, and the tagged set is identical on MRI and JRuby.
 | Env var | Value | Why |
 |---|---|---|
 | `TEST_MEMGRAPH` | `1` | Activates the `memgraph: false` exclusion |
-| `TEST_NEO4J_AUTH` | `none` | Memgraph runs with auth disabled → `AuthTokens.none` |
 | `TEST_NEO4J_DATABASE` | `memgraph` | Memgraph's default database (there is no `neo4j` db) |
 | `NEO4J_VERSION` | `5.11.0` | Memgraph's advertised Neo4j-compat level; feeds version-gated specs |
 
-Run it locally against a Memgraph container:
+The suite runs **with authentication on** (basic `neo4j`/`password`, the
+`driver_helper` default) so the auth path is exercised the same way as against
+Neo4j. Since Memgraph enables auth only once a user exists, a one-shot bootstrap
+creates that user before the suite runs — connecting with `AuthTokens.none` while
+the instance is still open:
 
 ```bash
 docker run -d -p 7687:7687 memgraph/memgraph
-TEST_MEMGRAPH=1 TEST_NEO4J_AUTH=none TEST_NEO4J_DATABASE=memgraph \
-  NEO4J_VERSION=5.11.0 bundle exec rspec
+# Create the user (turns auth on for the whole instance):
+bundle exec ruby -e "require 'neo4j/driver'; \
+  Neo4j::Driver::GraphDatabase.driver('bolt://localhost:7687', Neo4j::Driver::AuthTokens.none) { |d| \
+    d.session { |s| s.run(%q(CREATE USER neo4j IDENTIFIED BY 'password')).consume } }"
+TEST_MEMGRAPH=1 TEST_NEO4J_DATABASE=memgraph NEO4J_VERSION=5.11.0 bundle exec rspec
 ```
 
 ## Continuous integration
@@ -124,8 +136,9 @@ and the *same* `bundle exec rspec` invocation as the Neo4j matrix, just pointed 
 a Memgraph service container with the env vars above:
 
 - **`rspec-memgraph`** starts a `memgraph/memgraph` service container, waits for
-  the Bolt port, and runs `bundle exec rspec` with `TEST_MEMGRAPH=1` (+ auth-none,
-  `memgraph` database). No separate spec file, no separate workflow — it reuses the
+  the Bolt port, creates the `neo4j` user (enabling auth), and runs `bundle exec
+  rspec` with `TEST_MEMGRAPH=1` (+ `memgraph` database, basic auth). No separate
+  spec file, no separate workflow — it reuses the
   entire shared suite. It runs as a **matrix over both flavors**: latest CRuby
   (MRI pure-Ruby Bolt) and latest JRuby (Java driver).
 - **`memgraph-success`** is a version-free aggregator gate (mirroring

--- a/lib/mri/neo4j/driver/bolt/message/failure.rb
+++ b/lib/mri/neo4j/driver/bolt/message/failure.rb
@@ -15,17 +15,26 @@ module Neo4j
         # exposes the same fields regardless of the server's protocol version —
         # matching the Java driver's GqlStatusException behaviour.
         class Failure
-          # Code-prefix → driver exception class. Order matters: more specific
-          # patterns must come first.
+          # Code → driver exception class. Order matters: more specific patterns
+          # must come first.
+          #
+          # The broad rules classify by the code's **classification segment** (the
+          # second dotted part), matching the Java driver's `ErrorUtil` rather than
+          # keying on a literal `Neo.` vendor prefix. So a Bolt-compatible server
+          # that uses its own prefix — e.g. Memgraph's
+          # `Memgraph.ClientError.MemgraphError` — still maps to `ClientException`,
+          # not the base `Neo4jException`. Neo4j codes (`Neo.ClientError.…`) match
+          # these exactly as before. The leading rules stay `Neo.`-scoped because
+          # those subtypes are Neo4j-specific status codes.
           EXCEPTION_FOR_CODE = [
             [/^Neo\.ClientError\.Security\.Unauthorized/, Exceptions::AuthenticationException],
             [/^Neo\.ClientError\.Security\.AuthorizationExpired/, Exceptions::AuthorizationExpiredException],
             [/^Neo\.ClientError\.Security\.TokenExpired/, Exceptions::TokenExpiredException],
             [/^Neo\.ClientError\.Security/, Exceptions::SecurityException],
             [/^Neo\.ClientError\.Database\.DatabaseNotFound/, Exceptions::FatalDiscoveryException],
-            [/^Neo\.ClientError/, Exceptions::ClientException],
-            [/^Neo\.TransientError/, Exceptions::TransientException],
-            [/^Neo\.DatabaseError/, Exceptions::DatabaseException]
+            [/\A[^.]+\.ClientError(?:\.|\z)/, Exceptions::ClientException],
+            [/\A[^.]+\.TransientError(?:\.|\z)/, Exceptions::TransientException],
+            [/\A[^.]+\.DatabaseError(?:\.|\z)/, Exceptions::DatabaseException]
           ].freeze
 
           # Two `TransientError` codes the server may send that are actually

--- a/spec/shared/integration/bookmark_manager_spec.rb
+++ b/spec/shared/integration/bookmark_manager_spec.rb
@@ -4,7 +4,9 @@
 # plus session(bookmark_manager:) — in Ruby terms only (Set, Bookmark#value).
 # Impl-agnostic, so it runs on both flavors.
 RSpec.describe 'BookmarkManager' do
-  it 'tracks bookmarks across sessions and notifies the consumer on commit' do
+  # Memgraph has no causal-consistency bookmarks: commits produce no bookmark,
+  # so the manager's consumer is never notified and nothing is tracked.
+  it 'tracks bookmarks across sessions and notifies the consumer on commit', memgraph: false do
     consumed = nil
     manager = Neo4j::Driver::BookmarkManagers.default_manager(
       bookmarks_consumer: ->(bookmarks) { consumed = bookmarks }
@@ -27,7 +29,8 @@ RSpec.describe 'BookmarkManager' do
     expect(count).to eq 1
   end
 
-  it 'seeds the manager with initial_bookmarks' do
+  # Memgraph produces no bookmark after a commit, so there is nothing to seed.
+  it 'seeds the manager with initial_bookmarks', memgraph: false do
     # Produce a real bookmark from a vanilla session, then hand it to a
     # second manager as initial_bookmarks. The consumer should still
     # observe the bookmark set after a write that follows.

--- a/spec/shared/integration/bookmark_spec.rb
+++ b/spec/shared/integration/bookmark_spec.rb
@@ -25,13 +25,16 @@ RSpec.describe 'Bookmark' do
     expect(values.first).to start_with(value)
   end
 
-  it 'raises for invalid bookmark' do
+  # Memgraph has no causal-consistency bookmarks: commits return an empty
+  # bookmark set and invalid bookmarks are not rejected, so these expectations
+  # (non-empty bookmarks / ClientException on a bad bookmark) don't hold.
+  it 'raises for invalid bookmark', memgraph: false do
     invalid_bookmark = Neo4j::Driver::Bookmark.from('hi, this is an invalid bookmark')
     expect { driver.session(bookmarks: Set[invalid_bookmark], &:begin_transaction) }
       .to raise_error Neo4j::Driver::Exceptions::ClientException
   end
 
-  it 'remain after rollback tx' do
+  it 'remain after rollback tx', memgraph: false do
     driver.session do |session|
       bookmarks = preamble(session)
       session.begin_transaction do |tx|
@@ -42,7 +45,7 @@ RSpec.describe 'Bookmark' do
     end
   end
 
-  it 'remains after tx failure' do
+  it 'remains after tx failure', memgraph: false do
     driver.session do |session|
       bookmarks = preamble(session)
       tx = session.begin_transaction
@@ -51,7 +54,7 @@ RSpec.describe 'Bookmark' do
     end
   end
 
-  it 'remains after successful session run' do
+  it 'remains after successful session run', memgraph: false do
     driver.session do |session|
       bookmarks = preamble(session)
       session.run('RETURN 1').consume
@@ -59,7 +62,7 @@ RSpec.describe 'Bookmark' do
     end
   end
 
-  it 'remains after failed session run' do
+  it 'remains after failed session run', memgraph: false do
     driver.session do |session|
       bookmarks = preamble(session)
       expect { session.run('RETURN').consume }.to raise_error Neo4j::Driver::Exceptions::ClientException
@@ -67,7 +70,7 @@ RSpec.describe 'Bookmark' do
     end
   end
 
-  it 'is updated every committed tx' do
+  it 'is updated every committed tx', memgraph: false do
     driver.session do |session|
       expect(session.last_bookmarks).to be_empty
       expect(3.times.sum(Set.new) { create_and_expect(session) }.size).to eq 3
@@ -90,7 +93,8 @@ RSpec.describe 'Bookmark' do
     expect(driver.session(bookmarks: [bookmark], &:last_bookmarks)).to contain_exactly bookmark
   end
 
-  it 'fails on invalid bookmark using tx func' do
+  # Memgraph accepts any bookmark, so no InvalidBookmark ClientException.
+  it 'fails on invalid bookmark using tx func', memgraph: false do
     bookmark = Neo4j::Driver::Bookmark.from('hi, this is an invalid bookmark')
     driver.session(bookmarks: [bookmark]) do |session|
       expect { session.execute_read { |tx| tx.run('RETURN 1').single } }

--- a/spec/shared/integration/credentials_spec.rb
+++ b/spec/shared/integration/credentials_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe 'Credentials' do
     end
   end
 
-  it 'gets helpful error on invalid credentials' do
+  # Memgraph auth is disabled by default, so invalid credentials connect fine and no AuthenticationException is raised.
+  it 'gets helpful error on invalid credentials', memgraph: false do
     Neo4j::Driver::GraphDatabase.driver(uri, Neo4j::Driver::AuthTokens.basic(neo4j_user, 'thisisnotthepassword')) do |d|
       expect { d.session { |s| s.run('RETURN 1').consume } }
         .to raise_error(
@@ -34,7 +35,9 @@ RSpec.describe 'Credentials' do
     end
   end
 
-  it 'routing driver fails early on wrong credentials' do
+  # Memgraph has no neo4j:// routing (not a cluster) and auth is disabled: verify_connectivity raises
+  # ServiceUnavailableException about routing, not AuthenticationException.
+  it 'routing driver fails early on wrong credentials', memgraph: false do
     routing_uri = "neo4j://#{host}:#{port}"
     Neo4j::Driver::GraphDatabase.driver(routing_uri, Neo4j::Driver::AuthTokens.basic(neo4j_user, 'wrongSecret')) do |d|
       expect { d.verify_connectivity }

--- a/spec/shared/integration/credentials_spec.rb
+++ b/spec/shared/integration/credentials_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe 'Credentials' do
     end
   end
 
-  # Memgraph auth is disabled by default, so invalid credentials connect fine and no AuthenticationException is raised.
+  # Memgraph rejects invalid credentials with a ClientException "Authentication
+  # failure" (as the Java driver does), not AuthenticationException with Neo4j's
+  # "The client is unauthorized…" message.
   it 'gets helpful error on invalid credentials', memgraph: false do
     Neo4j::Driver::GraphDatabase.driver(uri, Neo4j::Driver::AuthTokens.basic(neo4j_user, 'thisisnotthepassword')) do |d|
       expect { d.session { |s| s.run('RETURN 1').consume } }
@@ -35,8 +37,9 @@ RSpec.describe 'Credentials' do
     end
   end
 
-  # Memgraph has no neo4j:// routing (not a cluster) and auth is disabled: verify_connectivity raises
-  # ServiceUnavailableException about routing, not AuthenticationException.
+  # Memgraph has no neo4j:// routing (not a cluster), so verify_connectivity fails
+  # fetching a routing table (ServiceUnavailableException), not with the
+  # AuthenticationException this expects.
   it 'routing driver fails early on wrong credentials', memgraph: false do
     routing_uri = "neo4j://#{host}:#{port}"
     Neo4j::Driver::GraphDatabase.driver(routing_uri, Neo4j::Driver::AuthTokens.basic(neo4j_user, 'wrongSecret')) do |d|

--- a/spec/shared/integration/direct_driver_spec.rb
+++ b/spec/shared/integration/direct_driver_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'DirectDriverSpec' do
     end
   end
 
-  it 'does not verify connectivity with bad auth token' do
+  # Memgraph auth is disabled by default, so AuthTokens.none connects fine and no SecurityException is raised.
+  it 'does not verify connectivity with bad auth token', memgraph: false do
     Neo4j::Driver::GraphDatabase.driver(uri, Neo4j::Driver::AuthTokens.none) do |driver|
       expect { driver.verify_connectivity }.to raise_error Neo4j::Driver::Exceptions::SecurityException
     end

--- a/spec/shared/integration/direct_driver_spec.rb
+++ b/spec/shared/integration/direct_driver_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'DirectDriverSpec' do
     end
   end
 
-  # Memgraph auth is disabled by default, so AuthTokens.none connects fine and no SecurityException is raised.
+  # With auth enabled, Memgraph rejects AuthTokens.none with a ClientException (as
+  # the Java driver does), not the SecurityException this expects.
   it 'does not verify connectivity with bad auth token', memgraph: false do
     Neo4j::Driver::GraphDatabase.driver(uri, Neo4j::Driver::AuthTokens.none) do |driver|
       expect { driver.verify_connectivity }.to raise_error Neo4j::Driver::Exceptions::SecurityException

--- a/spec/shared/integration/driver_completeness_spec.rb
+++ b/spec/shared/integration/driver_completeness_spec.rb
@@ -2,7 +2,10 @@
 
 RSpec.describe 'Driver completeness' do
   describe '#verify_authentication', version: '>=5' do
-    it 'returns true for the same credentials passed explicitly' do
+    # Java-driver-flavor only: its verify_authentication re-auth (LOGOFF/LOGON)
+    # behaves differently against Memgraph on Linux CI. MRI passes on both CRuby
+    # and the JVM, so this is the Java driver's behavior, not an MRI/platform gap.
+    it 'returns true for the same credentials passed explicitly', memgraph_jruby: false do
       good = Neo4j::Driver::AuthTokens.basic(neo4j_user, neo4j_password)
       expect(driver.verify_authentication(good)).to be(true)
     end

--- a/spec/shared/integration/driver_completeness_spec.rb
+++ b/spec/shared/integration/driver_completeness_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Driver completeness' do
       expect(driver.verify_authentication(good)).to be(true)
     end
 
-    it 'returns false for wrong credentials without disturbing the driver' do
+    # Memgraph auth is disabled by default, so wrong credentials verify as valid (returns true instead of false).
+    it 'returns false for wrong credentials without disturbing the driver', memgraph: false do
       bad = Neo4j::Driver::AuthTokens.basic(neo4j_user, 'definitely-not-the-password')
       expect(driver.verify_authentication(bad)).to be(false)
 

--- a/spec/shared/integration/driver_completeness_spec.rb
+++ b/spec/shared/integration/driver_completeness_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe 'Driver completeness' do
       expect(driver.verify_authentication(good)).to be(true)
     end
 
-    # Memgraph auth is disabled by default, so wrong credentials verify as valid (returns true instead of false).
+    # verify_authentication returns false only for an AuthenticationException;
+    # Memgraph rejects wrong credentials with a ClientException (as the Java driver
+    # does), which propagates instead of yielding false.
     it 'returns false for wrong credentials without disturbing the driver', memgraph: false do
       bad = Neo4j::Driver::AuthTokens.basic(neo4j_user, 'definitely-not-the-password')
       expect(driver.verify_authentication(bad)).to be(false)

--- a/spec/shared/integration/error_spec.rb
+++ b/spec/shared/integration/error_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe 'Error' do
   let(:session) { driver.session }
   after(:example) { session.close }
 
-  # Memgraph maps Cypher errors to the base Neo4jException (no Neo.* status
-  # code), so specs expecting a ClientException fail.
+  # Memgraph's error code isn't Neo4j's `…SyntaxError` and its message isn't
+  # "Invalid input …", so these code/message assertions don't hold.
   it 'throws helpful syntax error', memgraph: false do
     expect { session.run('invalid query').consume }
       .to raise_error(Neo4j::Driver::Exceptions::ClientException) do |e|
@@ -15,15 +15,13 @@ RSpec.describe 'Error' do
       end
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
-  it 'allows new query after recoverable error', memgraph: false do
+  it 'allows new query after recoverable error' do
     expect { session.run('invalid').consume }
       .to raise_error(Neo4j::Driver::Exceptions::ClientException)
     expect(session.run('RETURN 1').single[0]).to eq 1
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
-  it 'allows new transaction after recoverable error', memgraph: false do
+  it 'allows new transaction after recoverable error' do
     session.begin_transaction do |tx|
       expect { tx.run('invalid').consume }
         .to raise_error(Neo4j::Driver::Exceptions::ClientException)
@@ -62,8 +60,7 @@ RSpec.describe 'Error' do
   # label to avoid cross-test clashes; here a fixed test-specific label
   # is unambiguous within the suite and lets us pre-drop any leftover for
   # re-runnability without a finally (Java has none).
-  # Memgraph's Cypher dialect lacks `SHOW CONSTRAINTS ... YIELD` (parse error)
-  # and maps errors to the base Neo4jException, not ClientException.
+  # Memgraph's Cypher dialect lacks `SHOW CONSTRAINTS ... YIELD` (parse error).
   it 'handles failure at run time', memgraph: false do
     label = 'ErrorItRunTimeFailure'
     create = "CREATE CONSTRAINT FOR (a:`#{label}`) REQUIRE a.name IS UNIQUE"

--- a/spec/shared/integration/error_spec.rb
+++ b/spec/shared/integration/error_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe 'Error' do
   let(:session) { driver.session }
   after(:example) { session.close }
 
-  it 'throws helpful syntax error' do
+  # Memgraph maps Cypher errors to the base Neo4jException (no Neo.* status
+  # code), so specs expecting a ClientException fail.
+  it 'throws helpful syntax error', memgraph: false do
     expect { session.run('invalid query').consume }
       .to raise_error(Neo4j::Driver::Exceptions::ClientException) do |e|
         expect(e.code).to match(/SyntaxError/)
@@ -13,13 +15,15 @@ RSpec.describe 'Error' do
       end
   end
 
-  it 'allows new query after recoverable error' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'allows new query after recoverable error', memgraph: false do
     expect { session.run('invalid').consume }
       .to raise_error(Neo4j::Driver::Exceptions::ClientException)
     expect(session.run('RETURN 1').single[0]).to eq 1
   end
 
-  it 'allows new transaction after recoverable error' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'allows new transaction after recoverable error', memgraph: false do
     session.begin_transaction do |tx|
       expect { tx.run('invalid').consume }
         .to raise_error(Neo4j::Driver::Exceptions::ClientException)
@@ -41,7 +45,9 @@ RSpec.describe 'Error' do
     end
   end
 
-  it 'gets helpful error when trying to connect to http port' do
+  # Memgraph has no HTTP server on 7474, so connecting there is refused
+  # (ServiceUnavailableException) rather than the Neo4j "Server responded HTTP." ClientException.
+  it 'gets helpful error when trying to connect to http port', memgraph: false do
     Neo4j::Driver::GraphDatabase.driver('bolt://localhost:7474', basic_auth_token, encryption: false) do |d|
       expect { d.verify_connectivity }
         .to raise_error(Neo4j::Driver::Exceptions::ClientException) do |e|
@@ -56,7 +62,9 @@ RSpec.describe 'Error' do
   # label to avoid cross-test clashes; here a fixed test-specific label
   # is unambiguous within the suite and lets us pre-drop any leftover for
   # re-runnability without a finally (Java has none).
-  it 'handles failure at run time' do
+  # Memgraph's Cypher dialect lacks `SHOW CONSTRAINTS ... YIELD` (parse error)
+  # and maps errors to the base Neo4jException, not ClientException.
+  it 'handles failure at run time', memgraph: false do
     label = 'ErrorItRunTimeFailure'
     create = "CREATE CONSTRAINT FOR (a:`#{label}`) REQUIRE a.name IS UNIQUE"
     leftover = session.run('SHOW CONSTRAINTS YIELD name, labelsOrTypes WHERE $l IN labelsOrTypes RETURN name',

--- a/spec/shared/integration/parameters_spec.rb
+++ b/spec/shared/integration/parameters_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe 'Parameters' do
       test_property 6.28
     end
 
-    it 'is able to set and return ByteArray property' do
+    # Memgraph does not support byte-array (binary) parameters.
+    it 'is able to set and return ByteArray property', memgraph: false do
       proc = ->(v) { v.is_a?(String) && v.encoding == Encoding::BINARY }
       bytes = ->(size) { Random.new.bytes(size, &proc) }
       test_property bytes.call(0)
@@ -168,7 +169,8 @@ RSpec.describe 'Parameters' do
       it { is_expected.to eq value }
     end
 
-    context 'sends and receives long array of bytes' do
+    # Memgraph does not support byte-array (binary) parameters.
+    context 'sends and receives long array of bytes', memgraph: false do
       let(:value) { Random.new.bytes(LONG_VALUE_SIZE) }
 
       it { is_expected.to eq value }

--- a/spec/shared/integration/result_stream_spec.rb
+++ b/spec/shared/integration/result_stream_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  it 'is able to reuse session after failure' do
+  # Memgraph maps Cypher errors to the base Neo4jException (no Neo.* status
+  # code), so specs expecting a ClientException fail.
+  it 'is able to reuse session after failure', memgraph: false do
     driver.session do |session|
       expect { session.run('INVALID') }.to raise_error Neo4j::Driver::Exceptions::ClientException
       res2 = session.run('RETURN 1')
@@ -55,7 +57,8 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  it 'is able to access summary after transaction failure' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'is able to access summary after transaction failure', memgraph: false do
     driver.session do |session|
       result = nil
       expect do
@@ -70,7 +73,8 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  it 'is an empty list after failure' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'is an empty list after failure', memgraph: false do
     driver.session do |session|
       result = session.run('UNWIND [0, 1] as i RETURN 10 / i')
       expect(&result.method(:to_a)).to raise_error Neo4j::Driver::Exceptions::ClientException
@@ -94,7 +98,9 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  it 'converts immediatelly failing statement result to stream' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException
+  # (division by zero surfaces as "Invalid types" rather than "/ by zero").
+  it 'converts immediatelly failing statement result to stream', memgraph: false do
     driver.session do |session|
       seen = []
       expect { session.run('RETURN 10 / 0').each { |record| seen << record[0] } }
@@ -103,7 +109,8 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  it 'converts eventually failing statement result to stream' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'converts eventually failing statement result to stream', memgraph: false do
     driver.session do |session|
       seen = []
       expect { session.run('UNWIND range(5, 0, -1) AS x RETURN x / x').each { |record| seen << record[0] } }

--- a/spec/shared/integration/result_stream_spec.rb
+++ b/spec/shared/integration/result_stream_spec.rb
@@ -42,9 +42,7 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException (no Neo.* status
-  # code), so specs expecting a ClientException fail.
-  it 'is able to reuse session after failure', memgraph: false do
+  it 'is able to reuse session after failure' do
     driver.session do |session|
       expect { session.run('INVALID') }.to raise_error Neo4j::Driver::Exceptions::ClientException
       res2 = session.run('RETURN 1')
@@ -57,8 +55,7 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
-  it 'is able to access summary after transaction failure', memgraph: false do
+  it 'is able to access summary after transaction failure' do
     driver.session do |session|
       result = nil
       expect do
@@ -73,8 +70,7 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
-  it 'is an empty list after failure', memgraph: false do
+  it 'is an empty list after failure' do
     driver.session do |session|
       result = session.run('UNWIND [0, 1] as i RETURN 10 / i')
       expect(&result.method(:to_a)).to raise_error Neo4j::Driver::Exceptions::ClientException
@@ -98,8 +94,8 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException
-  # (division by zero surfaces as "Invalid types" rather than "/ by zero").
+  # The ClientException class now matches, but Memgraph's div-by-zero message is
+  # "Invalid types …" rather than "/ by zero", so the message assertion fails.
   it 'converts immediatelly failing statement result to stream', memgraph: false do
     driver.session do |session|
       seen = []
@@ -109,7 +105,8 @@ RSpec.describe 'ResultStream' do
     end
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  # The ClientException class now matches, but Memgraph's div-by-zero message
+  # differs from "/ by zero", so the message assertion fails.
   it 'converts eventually failing statement result to stream', memgraph: false do
     driver.session do |session|
       seen = []

--- a/spec/shared/integration/session_auth_spec.rb
+++ b/spec/shared/integration/session_auth_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe 'Per-session auth', version: '>=5.1' do
     end
   end
 
-  # Memgraph auth is disabled by default, so a wrong token still connects and no AuthenticationException is raised.
+  # Memgraph rejects a wrong token with a ClientException (as the Java driver does),
+  # not the AuthenticationException this expects.
   it 'rejects a wrong token with AuthenticationException at first use', memgraph: false do
     bad = Neo4j::Driver::AuthTokens.basic(neo4j_user, 'definitely-not-the-password')
     expect do
@@ -21,7 +22,8 @@ RSpec.describe 'Per-session auth', version: '>=5.1' do
     end.to raise_error(Neo4j::Driver::Exceptions::AuthenticationException)
   end
 
-  # Memgraph auth is disabled by default, so the wrong-token session doesn't raise, and the expectation fails.
+  # Memgraph rejects the wrong-token session with a ClientException (as the Java
+  # driver does), not the AuthenticationException this expects.
   it "doesn't poison the pool — subsequent default sessions still work", memgraph: false do
     bad = Neo4j::Driver::AuthTokens.basic(neo4j_user, 'definitely-not-the-password')
     expect do

--- a/spec/shared/integration/session_auth_spec.rb
+++ b/spec/shared/integration/session_auth_spec.rb
@@ -13,14 +13,16 @@ RSpec.describe 'Per-session auth', version: '>=5.1' do
     end
   end
 
-  it 'rejects a wrong token with AuthenticationException at first use' do
+  # Memgraph auth is disabled by default, so a wrong token still connects and no AuthenticationException is raised.
+  it 'rejects a wrong token with AuthenticationException at first use', memgraph: false do
     bad = Neo4j::Driver::AuthTokens.basic(neo4j_user, 'definitely-not-the-password')
     expect do
       driver.session(auth_token: bad) { |s| s.run('RETURN 1').consume }
     end.to raise_error(Neo4j::Driver::Exceptions::AuthenticationException)
   end
 
-  it "doesn't poison the pool — subsequent default sessions still work" do
+  # Memgraph auth is disabled by default, so the wrong-token session doesn't raise, and the expectation fails.
+  it "doesn't poison the pool — subsequent default sessions still work", memgraph: false do
     bad = Neo4j::Driver::AuthTokens.basic(neo4j_user, 'definitely-not-the-password')
     expect do
       driver.session(auth_token: bad) { |s| s.run('RETURN 1').consume }

--- a/spec/shared/integration/session_spec.rb
+++ b/spec/shared/integration/session_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe 'Session' do
     test_write_methods(Neo4j::Driver::AccessMode::WRITE, :execute_write)
   end
 
-  # Memgraph's Cypher dialect rejects `10/0` with "Invalid types: int and int for '/'" mapped to the base
-  # Neo4jException, not a ClientException with message "/ by zero".
+  # Memgraph raises ClientException for `10/0` but with message "Invalid types: int
+  # and int for '/'", not "/ by zero", so these message assertions fail.
   it 'rolls back write transaction in read session when function throws exception', memgraph: false do
     test_tx_rollback_when_function_throws_exception(Neo4j::Driver::AccessMode::READ, :execute_write)
   end
@@ -235,8 +235,9 @@ RSpec.describe 'Session' do
 
   # This multi threaded scenario deadlocks outside of neo4j on MRI due to Global Interpreter Lock und so it never comes
   # to the neo4j transaction deadlock which would be discovered and resolved by the neo4j server
-  # Memgraph maps a write-write conflict to the base Neo4jException ("Cannot resolve conflicting transactions"),
-  # not a TransientException with code Neo.TransientError.Transaction.DeadlockDetected, so it isn't classified/retried.
+  # Memgraph maps a write-write conflict to a TransientException, but its code is
+  # "Memgraph.TransientError.MemgraphError", not Neo4j's
+  # "Neo.TransientError.Transaction.DeadlockDetected", so the code assertion fails.
   it 'transaction run fails on deadlocks', concurrency: true, memgraph: false do
     node_id1 = 42
     node_id2 = 4242
@@ -295,8 +296,7 @@ RSpec.describe 'Session' do
     end
   end
 
-  # Same as above: Memgraph's conflict error is a base Neo4jException, not a retriable TransientException.
-  it 'write transaction function retries deadlocks', concurrency: true, memgraph: false do
+  it 'write transaction function retries deadlocks', concurrency: true do
     node_id1 = 42
     node_id2 = 4242
     node_id3 = 424_242
@@ -425,7 +425,7 @@ RSpec.describe 'Session' do
     end
   end
 
-  # Memgraph rejects `10 / 0` with base Neo4jException "Invalid types: int and int for '/'", not a ClientException "/ by zero".
+  # Memgraph raises ClientException for `10 / 0` but with message "Invalid types: int and int for '/'", not "/ by zero".
   it 'Close Cleanly When Run Error Consumed', memgraph: false do
     driver.session do |session|
       session.run('CREATE ()')
@@ -438,7 +438,7 @@ RSpec.describe 'Session' do
     end
   end
 
-  # Memgraph rejects `42 / 0` with base Neo4jException "Invalid types: int and int for '/'", not a ClientException "/ by zero".
+  # Memgraph raises ClientException for `42 / 0` but with message "Invalid types: int and int for '/'", not "/ by zero".
   it 'Consume Previous Result Before Running New Query', memgraph: false do
     driver.session do |session|
       session.run('UNWIND range(1000, 0, -1) AS x RETURN 42 / x')
@@ -468,8 +468,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  # Memgraph does not support the `CYPHER runtime=...` query prefix and rejects it with a parse error (base Neo4jException),
-  # so no ArithmeticError ClientException surfaces on close.
+  # Memgraph does not support the `CYPHER runtime=...` query prefix and rejects it
+  # with a parse error, so no "/ by zero" ArithmeticError surfaces on close.
   it 'reports failure in close', memgraph: false do
     session = driver.session
     session.run('CYPHER runtime=interpreted UNWIND [2, 4, 8, 0] AS x RETURN 32 / x')
@@ -624,7 +624,7 @@ RSpec.describe 'Session' do
     end
   end
 
-  # Memgraph rejects `10 / 0` with base Neo4jException "Invalid types: int and int for '/'", not a ClientException "/ by zero".
+  # Memgraph raises ClientException for `10 / 0` but with message "Invalid types: int and int for '/'", not "/ by zero".
   it 'Reports Failure In Summary', memgraph: false do
     driver.session do |session|
       query = 'UNWIND [1, 2, 3, 4, 0] AS x RETURN 10 / x'
@@ -828,8 +828,8 @@ RSpec.describe 'Session' do
     expect { session.close }.to raise_error(Neo4j::Driver::Exceptions::ClientException, /by zero|arithmetic/i)
   end
 
-  # Memgraph has no multi-database support: selecting the default "neo4j" database fails with
-  # base Neo4jException 'Tried to retrieve an unknown database "neo4j"'.
+  # Memgraph has no multi-database support: selecting the "neo4j" database fails
+  # with 'Tried to retrieve an unknown database "neo4j"'.
   it 'allows database name', version: '>=4', memgraph: false do
     driver.session(database: 'neo4j') do |session|
       expect(session.run('RETURN 1').single[0]).to eq 1
@@ -850,8 +850,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  # Memgraph has no multi-database support: an absent database yields base Neo4jException
-  # 'Tried to retrieve an unknown database "foo"', not a ClientException with code Neo.ClientError.Database.DatabaseNotFound.
+  # Memgraph has no multi-database support: an absent database yields
+  # 'Tried to retrieve an unknown database "foo"', not Neo4j's DatabaseNotFound.
   it 'errors using session.run when database is absent', version: '>=4', memgraph: false do
     session = driver.session(database: 'foo')
     expect { session.run('RETURN 1').consume }

--- a/spec/shared/integration/session_spec.rb
+++ b/spec/shared/integration/session_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe 'Session' do
     driver.close
   end
 
-  # Memgraph auth is disabled by default, so a nil/absent token connects fine and no AuthenticationException is raised.
+  # Memgraph rejects a nil/absent token with a ClientException (as the Java driver
+  # does), not the AuthenticationException this expects.
   it 'handles nil AuthToken', memgraph: false do
     Neo4j::Driver::GraphDatabase.driver(uri, nil) do |driver|
       expect(&driver.method(:verify_connectivity)).to raise_error Neo4j::Driver::Exceptions::AuthenticationException
@@ -448,7 +449,12 @@ RSpec.describe 'Session' do
 
   context "with 'bolt' scheme" do
     let(:scheme) { 'bolt' } # to avoid routing logic triggered by 'neo4j' scheme
-    it 'does not retry on connection acquisition timeout' do
+    # Memgraph's auth handshake (LOGON) is slow enough to exceed this test's tight
+    # 0.1s connection-acquisition timeout, so the driver surfaces a HELLO
+    # ServiceUnavailableException instead of the expected pool-acquisition
+    # ClientException. Timing-dependent but fails on both flavors. (Neo4j and
+    # auth-disabled Memgraph both complete the handshake within the budget.)
+    it 'does not retry on connection acquisition timeout', memgraph: false do
       max_pool_size = 3
       config = {
         max_connection_pool_size: max_pool_size,

--- a/spec/shared/integration/session_spec.rb
+++ b/spec/shared/integration/session_spec.rb
@@ -392,7 +392,9 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'does not propagate failure when streaming is cancelled' do
+  # Java-driver-flavor only: it surfaces the cancelled failing stream against
+  # Memgraph on Linux CI, where MRI discards it cleanly on both CRuby and the JVM.
+  it 'does not propagate failure when streaming is cancelled', memgraph_jruby: false do
     driver.session do |session|
       session.run('UNWIND range(20000, 0, -1) AS x RETURN 10 / x')
     end

--- a/spec/shared/integration/session_spec.rb
+++ b/spec/shared/integration/session_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe 'Session' do
     driver.close
   end
 
-  it 'handles nil AuthToken' do
+  # Memgraph auth is disabled by default, so a nil/absent token connects fine and no AuthenticationException is raised.
+  it 'handles nil AuthToken', memgraph: false do
     Neo4j::Driver::GraphDatabase.driver(uri, nil) do |driver|
       expect(&driver.method(:verify_connectivity)).to raise_error Neo4j::Driver::Exceptions::AuthenticationException
     end
@@ -53,19 +54,21 @@ RSpec.describe 'Session' do
     test_write_methods(Neo4j::Driver::AccessMode::WRITE, :execute_write)
   end
 
-  it 'rolls back write transaction in read session when function throws exception' do
+  # Memgraph's Cypher dialect rejects `10/0` with "Invalid types: int and int for '/'" mapped to the base
+  # Neo4jException, not a ClientException with message "/ by zero".
+  it 'rolls back write transaction in read session when function throws exception', memgraph: false do
     test_tx_rollback_when_function_throws_exception(Neo4j::Driver::AccessMode::READ, :execute_write)
   end
 
-  it 'rolls back write transaction in write session when function throws exception' do
+  it 'rolls back write transaction in write session when function throws exception', memgraph: false do
     test_tx_rollback_when_function_throws_exception(Neo4j::Driver::AccessMode::WRITE, :execute_write)
   end
 
-  it 'rolls back execute write in read session when function throws exception' do
+  it 'rolls back execute write in read session when function throws exception', memgraph: false do
     test_tx_rollback_when_function_throws_exception(Neo4j::Driver::AccessMode::READ, :execute_write)
   end
 
-  it 'rolls back execute write in write session when function throws exception' do
+  it 'rolls back execute write in write session when function throws exception', memgraph: false do
     test_tx_rollback_when_function_throws_exception(Neo4j::Driver::AccessMode::WRITE, :execute_write)
   end
 
@@ -185,7 +188,8 @@ RSpec.describe 'Session' do
     test_write_rollback_on_exception(:execute_write)
   end
 
-  it 'read tx committed without tx success' do
+  # Memgraph does not return a bookmark for a committed read-only transaction, so last_bookmarks stays empty.
+  it 'read tx committed without tx success', memgraph: false do
     driver.session do |session|
       expect(session.execute_read { |tx| tx.run('RETURN 42').single[0] }).to eq(42)
       expect(session.last_bookmarks.size).to eq 1
@@ -231,7 +235,9 @@ RSpec.describe 'Session' do
 
   # This multi threaded scenario deadlocks outside of neo4j on MRI due to Global Interpreter Lock und so it never comes
   # to the neo4j transaction deadlock which would be discovered and resolved by the neo4j server
-  it 'transaction run fails on deadlocks', concurrency: true do
+  # Memgraph maps a write-write conflict to the base Neo4jException ("Cannot resolve conflicting transactions"),
+  # not a TransientException with code Neo.TransientError.Transaction.DeadlockDetected, so it isn't classified/retried.
+  it 'transaction run fails on deadlocks', concurrency: true, memgraph: false do
     node_id1 = 42
     node_id2 = 4242
     new_node_id1 = 1
@@ -289,7 +295,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'write transaction function retries deadlocks', concurrency: true do
+  # Same as above: Memgraph's conflict error is a base Neo4jException, not a retriable TransientException.
+  it 'write transaction function retries deadlocks', concurrency: true, memgraph: false do
     node_id1 = 42
     node_id2 = 4242
     node_id3 = 424_242
@@ -376,7 +383,8 @@ RSpec.describe 'Session' do
     test_read_work_in_caller_thread(:execute_read)
   end
 
-  it 'Throws Run Failure Immediately And Closes Successfully' do
+  # Memgraph's Cypher dialect evaluates `1 * "x"` without error (no "Type mismatch" ClientException is raised).
+  it 'Throws Run Failure Immediately And Closes Successfully', memgraph: false do
     driver.session do |session|
       expect { session.run('RETURN 1 * "x"') }
         .to raise_error Neo4j::Driver::Exceptions::ClientException, /^Type mismatch/
@@ -396,7 +404,8 @@ RSpec.describe 'Session' do
     expect { result.map { |record| record[0] } }.to raise_error Neo4j::Driver::Exceptions::ResultConsumedException
   end
 
-  it 'Throw Run Failure Immediately After Multiple Successful Runs And Close Successfully' do
+  # Memgraph's Cypher dialect evaluates `1 * "x"` without error (no "Type mismatch" ClientException is raised).
+  it 'Throw Run Failure Immediately After Multiple Successful Runs And Close Successfully', memgraph: false do
     driver.session do |session|
       session.run('CREATE ()')
       session.run('CREATE ()')
@@ -405,7 +414,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'Throw Run Failure Immediately And Accept Subsequent Run' do
+  # Memgraph's Cypher dialect evaluates `1 * "x"` without error (no "Type mismatch" ClientException is raised).
+  it 'Throw Run Failure Immediately And Accept Subsequent Run', memgraph: false do
     driver.session do |session|
       session.run('CREATE ()')
       session.run('CREATE ()')
@@ -415,7 +425,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'Close Cleanly When Run Error Consumed' do
+  # Memgraph rejects `10 / 0` with base Neo4jException "Invalid types: int and int for '/'", not a ClientException "/ by zero".
+  it 'Close Cleanly When Run Error Consumed', memgraph: false do
     driver.session do |session|
       session.run('CREATE ()')
       expect do
@@ -427,7 +438,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'Consume Previous Result Before Running New Query' do
+  # Memgraph rejects `42 / 0` with base Neo4jException "Invalid types: int and int for '/'", not a ClientException "/ by zero".
+  it 'Consume Previous Result Before Running New Query', memgraph: false do
     driver.session do |session|
       session.run('UNWIND range(1000, 0, -1) AS x RETURN 42 / x')
       expect { session.run('RETURN 1') }.to raise_error Neo4j::Driver::Exceptions::ClientException, '/ by zero'
@@ -456,7 +468,9 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'reports failure in close' do
+  # Memgraph does not support the `CYPHER runtime=...` query prefix and rejects it with a parse error (base Neo4jException),
+  # so no ArithmeticError ClientException surfaces on close.
+  it 'reports failure in close', memgraph: false do
     session = driver.session
     session.run('CYPHER runtime=interpreted UNWIND [2, 4, 8, 0] AS x RETURN 32 / x')
     expect(&session.method(:close)).to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
@@ -464,7 +478,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'Does Not Allow Accessing Records After Summary' do
+  # Memgraph reports the summary query_type as "rw" for these read queries where Neo4j reports "r".
+  it 'Does Not Allow Accessing Records After Summary', memgraph: false do
     driver.session do |session|
       record_count = 10_000
       query = "UNWIND range(1, #{record_count}) AS x RETURN x"
@@ -528,7 +543,9 @@ RSpec.describe 'Session' do
   #  end
   # end
 
-  it 'allows long running query with connect timeout', concurrency: true do
+  # Memgraph resolves the write-write conflict immediately (rejecting the second query) instead of blocking on the
+  # row lock as Neo4j does, so the future is already resolved rather than pending.
+  it 'allows long running query with connect timeout', concurrency: true, memgraph: false do
     session1 = driver.session
     session2 = driver.session
 
@@ -579,7 +596,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'Allow Consuming Empty Result' do
+  # Memgraph reports the summary query_type as "rw" for this read query where Neo4j reports "r".
+  it 'Allow Consuming Empty Result', memgraph: false do
     driver.session do |session|
       result = session.run('UNWIND [] AS x RETURN x')
       summary = result.consume
@@ -595,7 +613,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'Consume' do
+  # Memgraph reports the summary query_type as "rw" for this read query where Neo4j reports "r".
+  it 'Consume', memgraph: false do
     driver.session do |session|
       query = 'UNWIND [1, 2, 3, 4, 5] AS x RETURN x'
       result = session.run(query)
@@ -605,7 +624,8 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'Reports Failure In Summary' do
+  # Memgraph rejects `10 / 0` with base Neo4jException "Invalid types: int and int for '/'", not a ClientException "/ by zero".
+  it 'Reports Failure In Summary', memgraph: false do
     driver.session do |session|
       query = 'UNWIND [1, 2, 3, 4, 0] AS x RETURN 10 / x'
       result = session.run(query)
@@ -808,13 +828,15 @@ RSpec.describe 'Session' do
     expect { session.close }.to raise_error(Neo4j::Driver::Exceptions::ClientException, /by zero|arithmetic/i)
   end
 
-  it 'allows database name', version: '>=4' do
+  # Memgraph has no multi-database support: selecting the default "neo4j" database fails with
+  # base Neo4jException 'Tried to retrieve an unknown database "neo4j"'.
+  it 'allows database name', version: '>=4', memgraph: false do
     driver.session(database: 'neo4j') do |session|
       expect(session.run('RETURN 1').single[0]).to eq 1
     end
   end
 
-  it 'allows database name using explicit transaction', version: '>=4' do
+  it 'allows database name using explicit transaction', version: '>=4', memgraph: false do
     driver.session(database: 'neo4j') do |session|
       session.begin_transaction do |tx|
         expect(tx.run('RETURN 1').single[0]).to eq 1
@@ -822,13 +844,15 @@ RSpec.describe 'Session' do
     end
   end
 
-  it 'allows database name using execute_read', version: '>=4' do
+  it 'allows database name using execute_read', version: '>=4', memgraph: false do
     driver.session(database: 'neo4j') do |session|
       expect(session.execute_read { |tx| tx.run('RETURN 1').single[0] }).to eq 1
     end
   end
 
-  it 'errors using session.run when database is absent', version: '>=4' do
+  # Memgraph has no multi-database support: an absent database yields base Neo4jException
+  # 'Tried to retrieve an unknown database "foo"', not a ClientException with code Neo.ClientError.Database.DatabaseNotFound.
+  it 'errors using session.run when database is absent', version: '>=4', memgraph: false do
     session = driver.session(database: 'foo')
     expect { session.run('RETURN 1').consume }
       .to raise_error(Neo4j::Driver::Exceptions::ClientException) do |e|
@@ -839,7 +863,7 @@ RSpec.describe 'Session' do
     session&.close
   end
 
-  it 'errors using explicit transaction when database is absent', version: '>=4' do
+  it 'errors using explicit transaction when database is absent', version: '>=4', memgraph: false do
     session = driver.session(database: 'foo')
     expect do
       tx = session.begin_transaction
@@ -852,7 +876,7 @@ RSpec.describe 'Session' do
     session&.close
   end
 
-  it 'errors using execute_read when database is absent', version: '>=4' do
+  it 'errors using execute_read when database is absent', version: '>=4', memgraph: false do
     session = driver.session(database: 'foo')
     expect { session.execute_read { |tx| tx.run('RETURN 1').consume } }
       .to raise_error(Neo4j::Driver::Exceptions::ClientException) do |e|

--- a/spec/shared/integration/summary_spec.rb
+++ b/spec/shared/integration/summary_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Summary' do
-  it 'contains basic metadata' do
+  # Memgraph's result-summary metadata differs from Neo4j's (query type,
+  # timing, statistics, plan/profile, notifications, system db), so these
+  # summary assertions don't hold against Memgraph.
+  it 'contains basic metadata', memgraph: false do
     driver.session do |session|
       statement_text = 'UNWIND [1, 2, 3, 4] AS n RETURN n AS number LIMIT $limit'
       statement_parameters = { limit: 10 }
@@ -18,7 +21,7 @@ RSpec.describe 'Summary' do
     end
   end
 
-  it 'contains time information' do
+  it 'contains time information', memgraph: false do
     driver.session do |session|
       summary = session.run('UNWIND range(1,1000) AS n RETURN n AS numbe').consume
       expect(summary.result_available_after).to be >= 0
@@ -26,7 +29,7 @@ RSpec.describe 'Summary' do
     end
   end
 
-  it 'contains correct statistics' do
+  it 'contains correct statistics', memgraph: false do
     driver.session do |session|
       expect(session.run('CREATE (n)').consume.counters.nodes_created).to eq 1
       expect(session.run('MATCH (n) DELETE (n)').consume.counters.nodes_deleted).to eq 1
@@ -49,7 +52,7 @@ RSpec.describe 'Summary' do
     end
   end
 
-  it 'contain correct statement type' do
+  it 'contain correct statement type', memgraph: false do
     driver.session do |session|
       expect(session.run('MATCH (n) RETURN 1').consume.query_type)
         .to eq Neo4j::Driver::Summary::QueryType::READ_ONLY
@@ -64,7 +67,7 @@ RSpec.describe 'Summary' do
     end
   end
 
-  it 'contains correct plan' do
+  it 'contains correct plan', memgraph: false do
     driver.session do |session|
       summary = session.run('EXPLAIN MATCH (n) RETURN 1').consume
 
@@ -78,7 +81,7 @@ RSpec.describe 'Summary' do
     end
   end
 
-  it 'contains profile' do
+  it 'contains profile', memgraph: false do
     driver.session do |session|
       summary = session.run('PROFILE RETURN 1').consume
 
@@ -96,7 +99,7 @@ RSpec.describe 'Summary' do
     end
   end
 
-  it 'contains notifications' do
+  it 'contains notifications', memgraph: false do
     driver.session do |session|
       # 'EXPLAIN MATCH (n), (m) RETURN n, m' seems to return notifications randomly. Server issue?
       # summary = session.run('EXPLAIN MATCH (n), (m) RETURN n, m').consume
@@ -125,7 +128,7 @@ RSpec.describe 'Summary' do
 
   # Ported from neo4j-java-driver SummaryIT.shouldGetSystemUpdates
   # (multi-database + admin command -> needs Neo4j 4+ enterprise).
-  it 'gets system updates', version: '>=4' do
+  it 'gets system updates', version: '>=4', memgraph: false do
     driver.session(database: 'system') do |session|
       # Java relies on a pristine system DB; our global cleaner only wipes
       # the default graph, so drop any leftover `foo` up front to keep the

--- a/spec/shared/integration/transaction_spec.rb
+++ b/spec/shared/integration/transaction_spec.rb
@@ -90,92 +90,92 @@ RSpec.describe 'Transaction' do
     end
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
-  it 'Rolls back Transaction After Failed Run And Commit And Session Successfully Begins New Transaction', memgraph: false do
-    tx = session.begin_transaction
-    expect { tx.run('invalid') }.to raise_error Neo4j::Driver::Exceptions::ClientException
-    expect(&tx.method(:commit)).to raise_error Neo4j::Driver::Exceptions::ClientException
+  # Every example here fails the same way against Memgraph: it maps Cypher
+  # errors to the base Neo4jException (no Neo.* status code) instead of the
+  # specific ClientException these specs expect (some also differ in dialect
+  # wording, e.g. "Unbound variable").
+  context 'when a run fails (Memgraph error semantics differ)', memgraph: false do
+    it 'Rolls back Transaction After Failed Run And Commit And Session Successfully Begins New Transaction' do
+      tx = session.begin_transaction
+      expect { tx.run('invalid') }.to raise_error Neo4j::Driver::Exceptions::ClientException
+      expect(&tx.method(:commit)).to raise_error Neo4j::Driver::Exceptions::ClientException
 
-    session.begin_transaction do |another_tx|
-      expect(another_tx.run('RETURN 1').single['1']).to eq 1
+      session.begin_transaction do |another_tx|
+        expect(another_tx.run('RETURN 1').single['1']).to eq 1
+      end
     end
-  end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
-  it 'rolls back tx if error with consume', memgraph: false do
-    expect do
+    it 'rolls back tx if error with consume' do
+      expect do
+        session.begin_transaction do |tx|
+          result = tx.run('invalid')
+          tx.commit
+          result.consume
+        end
+      end.to raise_error Neo4j::Driver::Exceptions::ClientException
+
+      session.begin_transaction do |another_tx|
+        expect(another_tx.run('RETURN 1').single['1']).to eq 1
+      end
+    end
+
+    it 'fails run' do
       session.begin_transaction do |tx|
-        result = tx.run('invalid')
-        tx.commit
-        result.consume
-      end
-    end.to raise_error Neo4j::Driver::Exceptions::ClientException
-
-    session.begin_transaction do |another_tx|
-      expect(another_tx.run('RETURN 1').single['1']).to eq 1
-    end
-  end
-
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException
-  # (and uses different dialect wording, e.g. "Unbound variable").
-  it 'fails run', memgraph: false do
-    session.begin_transaction do |tx|
-      expect { tx.run('RETURN Wrong') }.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
-        expect(error.code).to match(/SyntaxError/)
+        expect { tx.run('RETURN Wrong') }.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
+          expect(error.code).to match(/SyntaxError/)
+        end
       end
     end
-  end
 
-  # Not Implemented
-  # shouldBeResponsiveToThreadInterruptWhenWaitingForResult
-  # shouldBeResponsiveToThreadInterruptWhenWaitingForCommit
-  # shouldThrowWhenConnectionKilledDuringTransaction
-  # shouldThrowWhenConnectionKilledDuringTransactionMarkedForSuccess
+    # Not Implemented
+    # shouldBeResponsiveToThreadInterruptWhenWaitingForResult
+    # shouldBeResponsiveToThreadInterruptWhenWaitingForCommit
+    # shouldThrowWhenConnectionKilledDuringTransaction
+    # shouldThrowWhenConnectionKilledDuringTransactionMarkedForSuccess
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
-  it 'disallows queries after failure when results are consumed', memgraph: false do
-    session.begin_transaction do |tx|
-      expect(tx.run('UNWIND [1,2,3] AS x CREATE (:Node) RETURN x').map(&:first)).to eq [1, 2, 3]
-      expect { tx.run('RETURN unknown').consume }.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
-        expect(error.code).to match(/SyntaxError/)
-      end
-      expect { tx.run('CREATE (:OtherNode)').consume }
-        .to raise_error(Neo4j::Driver::Exceptions::ClientException, /^Cannot run more queries in this transaction/)
-      expect { tx.run('RETURN 42').consume }
-        .to raise_error(Neo4j::Driver::Exceptions::ClientException, /^Cannot run more queries in this transaction/)
-    end
-
-    expect(count_nodes_by_label(:Node)).to be_zero
-    expect(count_nodes_by_label(:OtherNode)).to be_zero
-  end
-
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
-  it 'rolls back when marked successful but one statement fails', memgraph: false do
-    expect do
+    it 'disallows queries after failure when results are consumed' do
       session.begin_transaction do |tx|
-        tx.run('CREATE (:Node1)')
-        tx.run('CREATE (:Node2)')
-        tx.run('CREATE SmthStrange')
-        # In java the code below might be or might be not executed as all `tx.run` are responding asynchronously and the
-        # exception might happen before any of the 3 subsequent lines is executed.
-        tx.run('CREATE (:Node3)')
-        tx.run('CREATE (:Node4)')
-
-        tx.commit
+        expect(tx.run('UNWIND [1,2,3] AS x CREATE (:Node) RETURN x').map(&:first)).to eq [1, 2, 3]
+        expect { tx.run('RETURN unknown').consume }
+          .to raise_error(Neo4j::Driver::Exceptions::ClientException) { |error| expect(error.code).to match(/SyntaxError/) }
+        expect { tx.run('CREATE (:OtherNode)').consume }
+          .to raise_error(Neo4j::Driver::Exceptions::ClientException, /^Cannot run more queries in this transaction/)
+        expect { tx.run('RETURN 42').consume }
+          .to raise_error(Neo4j::Driver::Exceptions::ClientException, /^Cannot run more queries in this transaction/)
       end
-    end.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
-      expect(error.code).to match(/SyntaxError/)
-      # corresponding java test is not deterministic
-      # expect(error.suppressed.size).to be >= 1
-      # suppressed = error.suppressed.first
-      # expect(suppressed).to be_a Neo4j::Driver::Exceptions::ClientException
-      # expect(suppressed.message).to start_with "Transaction can't be committed"
+
+      expect(count_nodes_by_label(:Node)).to be_zero
+      expect(count_nodes_by_label(:OtherNode)).to be_zero
     end
 
-    expect(count_nodes_by_label(:Node1)).to be_zero
-    expect(count_nodes_by_label(:Node2)).to be_zero
-    expect(count_nodes_by_label(:Node3)).to be_zero
-    expect(count_nodes_by_label(:Node4)).to be_zero
+    it 'rolls back when marked successful but one statement fails' do
+      expect do
+        session.begin_transaction do |tx|
+          tx.run('CREATE (:Node1)')
+          tx.run('CREATE (:Node2)')
+          tx.run('CREATE SmthStrange')
+          # In java the code below might or might not be executed, as all `tx.run`
+          # respond asynchronously and the exception might happen before any of
+          # the 3 subsequent lines is executed.
+          tx.run('CREATE (:Node3)')
+          tx.run('CREATE (:Node4)')
+
+          tx.commit
+        end
+      end.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
+        expect(error.code).to match(/SyntaxError/)
+        # corresponding java test is not deterministic
+        # expect(error.suppressed.size).to be >= 1
+        # suppressed = error.suppressed.first
+        # expect(suppressed).to be_a Neo4j::Driver::Exceptions::ClientException
+        # expect(suppressed.message).to start_with "Transaction can't be committed"
+      end
+
+      expect(count_nodes_by_label(:Node1)).to be_zero
+      expect(count_nodes_by_label(:Node2)).to be_zero
+      expect(count_nodes_by_label(:Node3)).to be_zero
+      expect(count_nodes_by_label(:Node4)).to be_zero
+    end
   end
 
   # Memgraph has no `tx.getMetaData` procedure, so tx metadata can't be read back.

--- a/spec/shared/integration/transaction_spec.rb
+++ b/spec/shared/integration/transaction_spec.rb
@@ -72,9 +72,7 @@ RSpec.describe 'Transaction' do
     session.run('match (n) return count(n)', nil)
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException (no Neo.* status
-  # code), so specs expecting a ClientException fail.
-  it 'handles failure after closing transaction', memgraph: false do
+  it 'handles failure after closing transaction' do
     tx = session.begin_transaction
     tx.run('CREATE (n) RETURN n').consume
     tx.commit
@@ -90,92 +88,92 @@ RSpec.describe 'Transaction' do
     end
   end
 
-  # Every example here fails the same way against Memgraph: it maps Cypher
-  # errors to the base Neo4jException (no Neo.* status code) instead of the
-  # specific ClientException these specs expect (some also differ in dialect
-  # wording, e.g. "Unbound variable").
-  context 'when a run fails (Memgraph error semantics differ)', memgraph: false do
-    it 'Rolls back Transaction After Failed Run And Commit And Session Successfully Begins New Transaction' do
-      tx = session.begin_transaction
-      expect { tx.run('invalid') }.to raise_error Neo4j::Driver::Exceptions::ClientException
-      expect(&tx.method(:commit)).to raise_error Neo4j::Driver::Exceptions::ClientException
+  it 'Rolls back Transaction After Failed Run And Commit And Session Successfully Begins New Transaction' do
+    tx = session.begin_transaction
+    expect { tx.run('invalid') }.to raise_error Neo4j::Driver::Exceptions::ClientException
+    expect(&tx.method(:commit)).to raise_error Neo4j::Driver::Exceptions::ClientException
 
-      session.begin_transaction do |another_tx|
-        expect(another_tx.run('RETURN 1').single['1']).to eq 1
-      end
+    session.begin_transaction do |another_tx|
+      expect(another_tx.run('RETURN 1').single['1']).to eq 1
     end
+  end
 
-    it 'rolls back tx if error with consume' do
-      expect do
-        session.begin_transaction do |tx|
-          result = tx.run('invalid')
-          tx.commit
-          result.consume
-        end
-      end.to raise_error Neo4j::Driver::Exceptions::ClientException
-
-      session.begin_transaction do |another_tx|
-        expect(another_tx.run('RETURN 1').single['1']).to eq 1
-      end
-    end
-
-    it 'fails run' do
+  it 'rolls back tx if error with consume' do
+    expect do
       session.begin_transaction do |tx|
-        expect { tx.run('RETURN Wrong') }.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
-          expect(error.code).to match(/SyntaxError/)
-        end
+        result = tx.run('invalid')
+        tx.commit
+        result.consume
       end
+    end.to raise_error Neo4j::Driver::Exceptions::ClientException
+
+    session.begin_transaction do |another_tx|
+      expect(another_tx.run('RETURN 1').single['1']).to eq 1
     end
+  end
 
-    # Not Implemented
-    # shouldBeResponsiveToThreadInterruptWhenWaitingForResult
-    # shouldBeResponsiveToThreadInterruptWhenWaitingForCommit
-    # shouldThrowWhenConnectionKilledDuringTransaction
-    # shouldThrowWhenConnectionKilledDuringTransactionMarkedForSuccess
-
-    it 'disallows queries after failure when results are consumed' do
-      session.begin_transaction do |tx|
-        expect(tx.run('UNWIND [1,2,3] AS x CREATE (:Node) RETURN x').map(&:first)).to eq [1, 2, 3]
-        expect { tx.run('RETURN unknown').consume }
-          .to raise_error(Neo4j::Driver::Exceptions::ClientException) { |error| expect(error.code).to match(/SyntaxError/) }
-        expect { tx.run('CREATE (:OtherNode)').consume }
-          .to raise_error(Neo4j::Driver::Exceptions::ClientException, /^Cannot run more queries in this transaction/)
-        expect { tx.run('RETURN 42').consume }
-          .to raise_error(Neo4j::Driver::Exceptions::ClientException, /^Cannot run more queries in this transaction/)
-      end
-
-      expect(count_nodes_by_label(:Node)).to be_zero
-      expect(count_nodes_by_label(:OtherNode)).to be_zero
-    end
-
-    it 'rolls back when marked successful but one statement fails' do
-      expect do
-        session.begin_transaction do |tx|
-          tx.run('CREATE (:Node1)')
-          tx.run('CREATE (:Node2)')
-          tx.run('CREATE SmthStrange')
-          # In java the code below might or might not be executed, as all `tx.run`
-          # respond asynchronously and the exception might happen before any of
-          # the 3 subsequent lines is executed.
-          tx.run('CREATE (:Node3)')
-          tx.run('CREATE (:Node4)')
-
-          tx.commit
-        end
-      end.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
+  # Memgraph's error code isn't Neo4j's `…SyntaxError`, so the code assertion
+  # fails (the ClientException class now matches).
+  it 'fails run', memgraph: false do
+    session.begin_transaction do |tx|
+      expect { tx.run('RETURN Wrong') }.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
         expect(error.code).to match(/SyntaxError/)
-        # corresponding java test is not deterministic
-        # expect(error.suppressed.size).to be >= 1
-        # suppressed = error.suppressed.first
-        # expect(suppressed).to be_a Neo4j::Driver::Exceptions::ClientException
-        # expect(suppressed.message).to start_with "Transaction can't be committed"
       end
-
-      expect(count_nodes_by_label(:Node1)).to be_zero
-      expect(count_nodes_by_label(:Node2)).to be_zero
-      expect(count_nodes_by_label(:Node3)).to be_zero
-      expect(count_nodes_by_label(:Node4)).to be_zero
     end
+  end
+
+  # Not Implemented
+  # shouldBeResponsiveToThreadInterruptWhenWaitingForResult
+  # shouldBeResponsiveToThreadInterruptWhenWaitingForCommit
+  # shouldThrowWhenConnectionKilledDuringTransaction
+  # shouldThrowWhenConnectionKilledDuringTransactionMarkedForSuccess
+
+  # Memgraph's error code isn't Neo4j's `…SyntaxError`, so the code assertion
+  # fails (the ClientException class now matches).
+  it 'disallows queries after failure when results are consumed', memgraph: false do
+    session.begin_transaction do |tx|
+      expect(tx.run('UNWIND [1,2,3] AS x CREATE (:Node) RETURN x').map(&:first)).to eq [1, 2, 3]
+      expect { tx.run('RETURN unknown').consume }
+        .to raise_error(Neo4j::Driver::Exceptions::ClientException) { |error| expect(error.code).to match(/SyntaxError/) }
+      expect { tx.run('CREATE (:OtherNode)').consume }
+        .to raise_error(Neo4j::Driver::Exceptions::ClientException, /^Cannot run more queries in this transaction/)
+      expect { tx.run('RETURN 42').consume }
+        .to raise_error(Neo4j::Driver::Exceptions::ClientException, /^Cannot run more queries in this transaction/)
+    end
+
+    expect(count_nodes_by_label(:Node)).to be_zero
+    expect(count_nodes_by_label(:OtherNode)).to be_zero
+  end
+
+  # Memgraph's error code isn't Neo4j's `…SyntaxError`, so the code assertion
+  # fails (the ClientException class now matches).
+  it 'rolls back when marked successful but one statement fails', memgraph: false do
+    expect do
+      session.begin_transaction do |tx|
+        tx.run('CREATE (:Node1)')
+        tx.run('CREATE (:Node2)')
+        tx.run('CREATE SmthStrange')
+        # In java the code below might or might not be executed, as all `tx.run`
+        # respond asynchronously and the exception might happen before any of
+        # the 3 subsequent lines is executed.
+        tx.run('CREATE (:Node3)')
+        tx.run('CREATE (:Node4)')
+
+        tx.commit
+      end
+    end.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
+      expect(error.code).to match(/SyntaxError/)
+      # corresponding java test is not deterministic
+      # expect(error.suppressed.size).to be >= 1
+      # suppressed = error.suppressed.first
+      # expect(suppressed).to be_a Neo4j::Driver::Exceptions::ClientException
+      # expect(suppressed.message).to start_with "Transaction can't be committed"
+    end
+
+    expect(count_nodes_by_label(:Node1)).to be_zero
+    expect(count_nodes_by_label(:Node2)).to be_zero
+    expect(count_nodes_by_label(:Node3)).to be_zero
+    expect(count_nodes_by_label(:Node4)).to be_zero
   end
 
   # Memgraph has no `tx.getMetaData` procedure, so tx metadata can't be read back.
@@ -240,7 +238,8 @@ RSpec.describe 'Transaction' do
       .to raise_error(Neo4j::Driver::Exceptions::ClientException, /Can't commit.*rolled back/)
   end
 
-  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  # Memgraph's error code isn't Neo4j's `…SyntaxError` and its commit-after-failure
+  # message differs, so the code/message assertions fail (ClientException matches).
   it 'fails to commit after failure', memgraph: false do
     tx = session.begin_transaction
     xs = tx.run('UNWIND [1,2,3] AS x CREATE (:Node) RETURN x').to_a.map { |r| r[0] }

--- a/spec/shared/integration/transaction_spec.rb
+++ b/spec/shared/integration/transaction_spec.rb
@@ -72,7 +72,9 @@ RSpec.describe 'Transaction' do
     session.run('match (n) return count(n)', nil)
   end
 
-  it 'handles failure after closing transaction' do
+  # Memgraph maps Cypher errors to the base Neo4jException (no Neo.* status
+  # code), so specs expecting a ClientException fail.
+  it 'handles failure after closing transaction', memgraph: false do
     tx = session.begin_transaction
     tx.run('CREATE (n) RETURN n').consume
     tx.commit
@@ -88,7 +90,8 @@ RSpec.describe 'Transaction' do
     end
   end
 
-  it 'Rolls back Transaction After Failed Run And Commit And Session Successfully Begins New Transaction' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'Rolls back Transaction After Failed Run And Commit And Session Successfully Begins New Transaction', memgraph: false do
     tx = session.begin_transaction
     expect { tx.run('invalid') }.to raise_error Neo4j::Driver::Exceptions::ClientException
     expect(&tx.method(:commit)).to raise_error Neo4j::Driver::Exceptions::ClientException
@@ -98,7 +101,8 @@ RSpec.describe 'Transaction' do
     end
   end
 
-  it 'rolls back tx if error with consume' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'rolls back tx if error with consume', memgraph: false do
     expect do
       session.begin_transaction do |tx|
         result = tx.run('invalid')
@@ -112,7 +116,9 @@ RSpec.describe 'Transaction' do
     end
   end
 
-  it 'fails run' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException
+  # (and uses different dialect wording, e.g. "Unbound variable").
+  it 'fails run', memgraph: false do
     session.begin_transaction do |tx|
       expect { tx.run('RETURN Wrong') }.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
         expect(error.code).to match(/SyntaxError/)
@@ -126,7 +132,8 @@ RSpec.describe 'Transaction' do
   # shouldThrowWhenConnectionKilledDuringTransaction
   # shouldThrowWhenConnectionKilledDuringTransactionMarkedForSuccess
 
-  it 'disallows queries after failure when results are consumed' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'disallows queries after failure when results are consumed', memgraph: false do
     session.begin_transaction do |tx|
       expect(tx.run('UNWIND [1,2,3] AS x CREATE (:Node) RETURN x').map(&:first)).to eq [1, 2, 3]
       expect { tx.run('RETURN unknown').consume }.to raise_error(Neo4j::Driver::Exceptions::ClientException) do |error|
@@ -142,7 +149,8 @@ RSpec.describe 'Transaction' do
     expect(count_nodes_by_label(:OtherNode)).to be_zero
   end
 
-  it 'rolls back when marked successful but one statement fails' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'rolls back when marked successful but one statement fails', memgraph: false do
     expect do
       session.begin_transaction do |tx|
         tx.run('CREATE (:Node1)')
@@ -170,7 +178,8 @@ RSpec.describe 'Transaction' do
     expect(count_nodes_by_label(:Node4)).to be_zero
   end
 
-  it 'accepts metadata on begin_transaction' do
+  # Memgraph has no `tx.getMetaData` procedure, so tx metadata can't be read back.
+  it 'accepts metadata on begin_transaction', memgraph: false do
     metadata = { foo: 'bar', baz: 1 }
     session.begin_transaction(metadata: metadata) do |tx|
       result = tx.run('CALL tx.getMetaData()').single.first
@@ -231,7 +240,8 @@ RSpec.describe 'Transaction' do
       .to raise_error(Neo4j::Driver::Exceptions::ClientException, /Can't commit.*rolled back/)
   end
 
-  it 'fails to commit after failure' do
+  # Memgraph maps Cypher errors to the base Neo4jException, not ClientException.
+  it 'fails to commit after failure', memgraph: false do
     tx = session.begin_transaction
     xs = tx.run('UNWIND [1,2,3] AS x CREATE (:Node) RETURN x').to_a.map { |r| r[0] }
     expect(xs).to eq [1, 2, 3]

--- a/spec/shared/neo4j/driver/dev_manual_examples_spec.rb
+++ b/spec/shared/neo4j/driver/dev_manual_examples_spec.rb
@@ -300,7 +300,9 @@ RSpec.describe Neo4j::Driver do
     end
   end
 
-  context '5. Notification config', version: '>=5' do
+  # Memgraph: shortestPath is not a Cypher parser keyword, so the subject query
+  # fails to parse (also notification-config severity/category differences).
+  context '5. Notification config', version: '>=5', memgraph: false do
     subject do
       driver.session do |session|
         result = session.run(

--- a/spec/shared/neo4j/driver/duration_spec.rb
+++ b/spec/shared/neo4j/driver/duration_spec.rb
@@ -53,13 +53,15 @@ RSpec.describe Neo4j::Driver::Types::Duration do
       it { is_expected.to eq param }
     end
 
-    context 'when -1 nanosecond' do
+    # Memgraph truncates durations to microsecond precision (999999999ns -> 999999000ns).
+    context 'when -1 nanosecond', memgraph: false do
       let(:param) { described_class.new(0, 0, 0, -1) }
 
       it { is_expected.to eq param }
     end
 
-    context 'when 1 nanosecond' do
+    # Memgraph drops sub-microsecond nanoseconds (1ns -> 0).
+    context 'when 1 nanosecond', memgraph: false do
       let(:param) { described_class.new(0, 0, 0, 1) }
 
       it { is_expected.to eq param }
@@ -71,7 +73,8 @@ RSpec.describe Neo4j::Driver::Types::Duration do
       it { is_expected.to eq param }
     end
 
-    context 'when 1 month (to test month normalization)' do
+    # Memgraph normalizes months into days+seconds (1 month -> 30 days + 37746 seconds).
+    context 'when 1 month (to test month normalization)', memgraph: false do
       let(:param) { described_class.new(1, 0, 0, 0) }
 
       it { is_expected.to eq param }
@@ -85,19 +88,22 @@ RSpec.describe Neo4j::Driver::Types::Duration do
       end
     end
 
-    context 'when 1 year only' do
+    # Memgraph only accepts P[nD]T[nH][nM][nS] duration strings; year/month designators are rejected.
+    context 'when 1 year only', memgraph: false do
       let(:duration) { 'P1Y' }
 
       it { is_expected.to eq described_class.new(12, 0, 0, 0) }
     end
 
-    context 'when 1 year 2 months' do
+    # Memgraph only accepts P[nD]T[nH][nM][nS] duration strings; year/month designators are rejected.
+    context 'when 1 year 2 months', memgraph: false do
       let(:duration) { 'P1Y2M' }
 
       it { is_expected.to eq described_class.new(14, 0, 0, 0) }
     end
 
-    context 'when 0.9 years (Neo4j normalizes to 10 months + extras)' do
+    # Memgraph only accepts P[nD]T[nH][nM][nS] duration strings; year designator is rejected.
+    context 'when 0.9 years (Neo4j normalizes to 10 months + extras)', memgraph: false do
       let(:duration) { 'P0.9Y' }
 
       it 'returns normalized duration' do
@@ -110,7 +116,8 @@ RSpec.describe Neo4j::Driver::Types::Duration do
       end
     end
 
-    context 'when half month (Neo4j normalizes to ~15 days)' do
+    # Memgraph only accepts P[nD]T[nH][nM][nS] duration strings; the month designator is rejected.
+    context 'when half month (Neo4j normalizes to ~15 days)', memgraph: false do
       let(:duration) { 'P0.5M' }
 
       it 'returns normalized duration' do
@@ -138,7 +145,8 @@ RSpec.describe Neo4j::Driver::Types::Duration do
   end
 
   shared_examples 'duration' do
-    context 'when duration with all components' do
+    # Memgraph only accepts P[nD]T[nH][nM][nS] duration strings; year/month/week designators are rejected.
+    context 'when duration with all components', memgraph: false do
       let(:param) { 'P1Y2M3W10DT12H45M30.01S' }
 
       it { is_expected.to be true }
@@ -150,7 +158,8 @@ RSpec.describe Neo4j::Driver::Types::Duration do
       it { is_expected.to be true }
     end
 
-    context 'when half month' do
+    # Memgraph only accepts P[nD]T[nH][nM][nS] duration strings; the month designator is rejected.
+    context 'when half month', memgraph: false do
       let(:param) { 'P0.5M' }
 
       it { is_expected.to be true }

--- a/spec/shared/neo4j/driver/exceptions/authentication_exception_spec.rb
+++ b/spec/shared/neo4j/driver/exceptions/authentication_exception_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Neo4j::Driver::Exceptions::AuthenticationException do
-  it 'wrong credentials' do
+  # Memgraph does not raise an AuthenticationException here (verify_connectivity
+  # succeeds), so this Neo4j-specific auth behavior does not apply.
+  it 'wrong credentials', memgraph: false do
     Neo4j::Driver::GraphDatabase
       .driver(uri, Neo4j::Driver::AuthTokens.basic('neo4j', 'wrong_password')) do |driver|
       expect { driver.verify_connectivity }.to raise_exception described_class

--- a/spec/shared/neo4j/driver/exceptions/authentication_exception_spec.rb
+++ b/spec/shared/neo4j/driver/exceptions/authentication_exception_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe Neo4j::Driver::Exceptions::AuthenticationException do
-  # Memgraph does not raise an AuthenticationException here (verify_connectivity
-  # succeeds), so this Neo4j-specific auth behavior does not apply.
-  it 'wrong credentials', memgraph: false do
+# Memgraph does not raise an AuthenticationException here (verify_connectivity
+# succeeds), so this Neo4j-specific auth behavior does not apply.
+RSpec.describe Neo4j::Driver::Exceptions::AuthenticationException, memgraph: false do
+  it 'wrong credentials' do
     Neo4j::Driver::GraphDatabase
       .driver(uri, Neo4j::Driver::AuthTokens.basic('neo4j', 'wrong_password')) do |driver|
       expect { driver.verify_connectivity }.to raise_exception described_class

--- a/spec/shared/neo4j/driver/exceptions/authentication_exception_spec.rb
+++ b/spec/shared/neo4j/driver/exceptions/authentication_exception_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Memgraph does not raise an AuthenticationException here (verify_connectivity
-# succeeds), so this Neo4j-specific auth behavior does not apply.
+# With auth enabled, Memgraph rejects wrong credentials with a ClientException (as
+# the Java driver does), not Neo4j's AuthenticationException.
 RSpec.describe Neo4j::Driver::Exceptions::AuthenticationException, memgraph: false do
   it 'wrong credentials' do
     Neo4j::Driver::GraphDatabase

--- a/spec/shared/neo4j/driver/exceptions/client_exception_spec.rb
+++ b/spec/shared/neo4j/driver/exceptions/client_exception_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Memgraph maps errors to base Neo4jException, not Neo4j's ClientException.
-RSpec.describe Neo4j::Driver::Exceptions::ClientException, memgraph: false do
+RSpec.describe Neo4j::Driver::Exceptions::ClientException do
   it 'incorrect syntax' do
     expect do
       session = driver.session

--- a/spec/shared/neo4j/driver/exceptions/client_exception_spec.rb
+++ b/spec/shared/neo4j/driver/exceptions/client_exception_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe Neo4j::Driver::Exceptions::ClientException do
-  # Memgraph maps errors to base Neo4jException, not Neo4j's ClientException.
-  it 'incorrect syntax', memgraph: false do
+# Memgraph maps errors to base Neo4jException, not Neo4j's ClientException.
+RSpec.describe Neo4j::Driver::Exceptions::ClientException, memgraph: false do
+  it 'incorrect syntax' do
     expect do
       session = driver.session
       driver.session.run('CRETE ()').to_a

--- a/spec/shared/neo4j/driver/exceptions/client_exception_spec.rb
+++ b/spec/shared/neo4j/driver/exceptions/client_exception_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Neo4j::Driver::Exceptions::ClientException do
-  it 'incorrect syntax' do
+  # Memgraph maps errors to base Neo4jException, not Neo4j's ClientException.
+  it 'incorrect syntax', memgraph: false do
     expect do
       session = driver.session
       driver.session.run('CRETE ()').to_a

--- a/spec/shared/neo4j/driver/execute_query_spec.rb
+++ b/spec/shared/neo4j/driver/execute_query_spec.rb
@@ -3,7 +3,8 @@
 RSpec.describe Neo4j::Driver do
   describe '#execute_query', version: '>=5' do
     context 'when querying the database' do
-      it 'accepts query with params hash and config hash' do
+      # Memgraph: no named 'neo4j' database ("Tried to retrieve an unknown database").
+      it 'accepts query with params hash and config hash', memgraph: false do
         expect do
           driver.execute_query(
             'MATCH (p:Person {age: $age}) RETURN p.name AS name',
@@ -68,7 +69,8 @@ RSpec.describe Neo4j::Driver do
     end
 
     context 'when using query configuration' do
-      it 'accepts params hash and config hash together' do
+      # Memgraph: no named 'neo4j' database ("Tried to retrieve an unknown database").
+      it 'accepts params hash and config hash together', memgraph: false do
         expect do
           driver.execute_query(
             'MATCH (p:Person) RETURN p.name',
@@ -130,7 +132,8 @@ RSpec.describe Neo4j::Driver do
         end.not_to raise_error
       end
 
-      it 'accepts shortestPath query with keyword parameters' do
+      # Memgraph: shortestPath is not a Cypher parser keyword (parse error).
+      it 'accepts shortestPath query with keyword parameters', memgraph: false do
         expect do
           driver.execute_query(
             'MATCH p=shortestPath((:Person {name: $start})-[*]->(:Person {name: $end})) RETURN p',
@@ -142,7 +145,8 @@ RSpec.describe Neo4j::Driver do
     end
 
     context 'parameter handling' do
-      it 'handles params hash and config hash together' do
+      # Memgraph: no named 'neo4j' database ("Tried to retrieve an unknown database").
+      it 'handles params hash and config hash together', memgraph: false do
         expect do
           driver.execute_query(
             'MATCH (p:Person {age: $age, name: $name}) RETURN p',

--- a/spec/shared/neo4j/driver/graph_database_spec.rb
+++ b/spec/shared/neo4j/driver/graph_database_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Neo4j::Driver::GraphDatabase do
       it { is_expected.to eq 1 }
     end
 
-    context 'when neo4j' do
+    # Memgraph: single-instance, not a cluster, so the neo4j:// routing scheme
+    # cannot fetch a routing table (raises ServiceUnavailable).
+    context 'when neo4j', memgraph: false do
       let(:scheme) { 'neo4j' }
       it { is_expected.to eq 1 }
     end

--- a/spec/shared/neo4j/driver/simplified_examples_spec.rb
+++ b/spec/shared/neo4j/driver/simplified_examples_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Neo4j::Driver do
     expect(result.first).to eq 'John'
   end
 
-  # Memgraph maps errors to base Neo4jException (no ClientException) and uses a
-  # different message ("Redeclaring variable" instead of "Type mismatch:").
+  # Memgraph raises ClientException but with a different message
+  # ("Redeclaring variable" instead of "Type mismatch:").
   it 'raises type mismatch error execute_read', memgraph: false do
     driver.session do |session|
       expect do
@@ -46,8 +46,8 @@ RSpec.describe Neo4j::Driver do
     end
   end
 
-  # Memgraph maps errors to base Neo4jException (no ClientException) and uses a
-  # different message ("Redeclaring variable" instead of "Type mismatch:").
+  # Memgraph raises ClientException but with a different message
+  # ("Redeclaring variable" instead of "Type mismatch:").
   it 'raises type mismatch error in explicit transaction on close', memgraph: false do
     driver.session do |session|
       tx = session.begin_transaction
@@ -58,8 +58,8 @@ RSpec.describe Neo4j::Driver do
     end
   end
 
-  # Memgraph maps errors to base Neo4jException (no ClientException) and uses a
-  # different message ("Failed to remove node..." instead of "Cannot delete").
+  # Memgraph raises ClientException but with a different message
+  # ("Failed to remove node..." instead of "Cannot delete").
   it 'raise exception on delete without detach', memgraph: false do
     driver.session do |session|
       session.execute_write do |tx|

--- a/spec/shared/neo4j/driver/simplified_examples_spec.rb
+++ b/spec/shared/neo4j/driver/simplified_examples_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe Neo4j::Driver do
     expect(result.first).to eq 'John'
   end
 
-  it 'raises type mismatch error execute_read' do
+  # Memgraph maps errors to base Neo4jException (no ClientException) and uses a
+  # different message ("Redeclaring variable" instead of "Type mismatch:").
+  it 'raises type mismatch error execute_read', memgraph: false do
     driver.session do |session|
       expect do
         session.execute_read do |tx|
@@ -44,7 +46,9 @@ RSpec.describe Neo4j::Driver do
     end
   end
 
-  it 'raises type mismatch error in explicit transaction on close' do
+  # Memgraph maps errors to base Neo4jException (no ClientException) and uses a
+  # different message ("Redeclaring variable" instead of "Type mismatch:").
+  it 'raises type mismatch error in explicit transaction on close', memgraph: false do
     driver.session do |session|
       tx = session.begin_transaction
       expect { tx.run('MATCH (r) MATCH ()-[r]-() RETURN r') }
@@ -54,7 +58,9 @@ RSpec.describe Neo4j::Driver do
     end
   end
 
-  it 'raise exception on delete without detach' do
+  # Memgraph maps errors to base Neo4jException (no ClientException) and uses a
+  # different message ("Failed to remove node..." instead of "Cannot delete").
+  it 'raise exception on delete without detach', memgraph: false do
     driver.session do |session|
       session.execute_write do |tx|
         tx.run('CREATE (:Label)-[:REL]->()')

--- a/spec/shared/neo4j/driver/temporal_types_spec.rb
+++ b/spec/shared/neo4j/driver/temporal_types_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe Neo4j::Driver do
       it { is_expected.to eq result }
     end
 
-    context 'when epochMillis' do
+    # Memgraph's datetime() does not support the epochMillis construction key.
+    context 'when epochMillis', memgraph: false do
       let(:function) { 'datetime({epochMillis: 3360000})' }
       let(:result) { ActiveSupport::TimeZone.new('UTC').parse('1970-01-01 00:56:00') }
 
@@ -119,7 +120,8 @@ RSpec.describe Neo4j::Driver do
       it { is_expected.to be true }
     end
 
-    context 'when epochMillis' do
+    # Memgraph's datetime() does not support the epochMillis construction key.
+    context 'when epochMillis', memgraph: false do
       let(:param) { { epochMillis: 3_360_000 } }
 
       it { is_expected.to be true }
@@ -178,13 +180,15 @@ RSpec.describe Neo4j::Driver do
       it { is_expected.to be true }
     end
 
-    context 'when epochMillis' do
+    # Memgraph's datetime() does not support the epochMillis construction key.
+    context 'when epochMillis', memgraph: false do
       let(:param) { { epochMillis: 3_360_000 } }
 
       it { is_expected.to be true }
     end
 
-    context 'when nanosecond' do
+    # Memgraph's datetime() does not support epochSeconds/nanosecond construction keys.
+    context 'when nanosecond', memgraph: false do
       let(:param) { { epochSeconds: 1, nanosecond: 1 } }
 
       it { is_expected.to be true }

--- a/spec/shared/neo4j/driver/temporal_types_spec.rb
+++ b/spec/shared/neo4j/driver/temporal_types_spec.rb
@@ -15,24 +15,46 @@ RSpec.describe Neo4j::Driver do
       it { is_expected.to eq param }
     end
 
+    # Neo4j stores temporal values at nanosecond precision; Memgraph truncates to
+    # microseconds. Time.now/DateTime.now carry full nanosecond precision on Linux,
+    # so the exact-value round-trip only holds on Neo4j — but a microsecond-truncated
+    # value round-trips exactly on BOTH, so each case has a parallel µs context.
     context 'when DateTime as Time' do
       let(:param) { Time.now.in_time_zone(TZInfo::Timezone.get('UTC')).change(zone: '+07:00') }
 
-      it { is_expected.to eq param }
+      it('round-trips full nanosecond precision', memgraph: false) { is_expected.to eq param }
+
+      context 'truncated to microseconds' do
+        let(:param) { super().floor(6) }
+
+        it { is_expected.to eq param }
+      end
     end
 
     context 'when DateTime as plain Time' do
       let(:param) { Time.now }
 
       it { is_expected.to be_a Time }
-      it { is_expected.to eq param }
+      it('round-trips full nanosecond precision', memgraph: false) { is_expected.to eq param }
+
+      context 'truncated to microseconds' do
+        let(:param) { super().floor(6) }
+
+        it { is_expected.to eq param }
+      end
     end
 
     context 'when DateTime as DateTime' do
       let(:param) { DateTime.now }
 
       it { is_expected.to be_a Time }
-      it { is_expected.to eq param }
+      it('round-trips full nanosecond precision', memgraph: false) { is_expected.to eq param }
+
+      context 'truncated to microseconds' do
+        let(:param) { super().to_time.floor(6).to_datetime }
+
+        it { is_expected.to eq param }
+      end
     end
   end
 

--- a/spec/shared/neo4j/driver/types/local_date_time_spec.rb
+++ b/spec/shared/neo4j/driver/types/local_date_time_spec.rb
@@ -69,11 +69,18 @@ RSpec.describe Neo4j::Driver::Types::LocalDateTime do
     end
 
     let(:function) { %{localdatetime("#{localdatetime}")} }
+    let(:result) { described_class.parse(localdatetime) }
 
-    # Memgraph requires zero-padded YYYY-MM-DD; it rejects single-digit month/day like '2018-1-1'.
-    context 'when LocalDateTime', memgraph: false do
+    # Memgraph rejects single-digit month/day; kept for Neo4j's lenient parsing.
+    context 'when LocalDateTime (single-digit month/day)', memgraph: false do
       let(:localdatetime) { '2018-1-1T12:34:00' }
-      let(:result) { described_class.parse(localdatetime) }
+
+      it { is_expected.to eq result }
+    end
+
+    # Parallel zero-padded value that both Neo4j and Memgraph accept.
+    context 'when LocalDateTime (zero-padded)' do
+      let(:localdatetime) { '2018-01-01T12:34:00' }
 
       it { is_expected.to eq result }
     end
@@ -89,9 +96,16 @@ RSpec.describe Neo4j::Driver::Types::LocalDateTime do
       end
     end
 
-    # Memgraph requires zero-padded YYYY-MM-DD; it rejects single-digit month/day like '2018-1-1'.
-    context 'when LocalDateTime', memgraph: false do
+    # Memgraph rejects single-digit month/day; kept for Neo4j's lenient parsing.
+    context 'when LocalDateTime (single-digit month/day)', memgraph: false do
       let(:param) { '2018-1-1T12:34:00' }
+
+      it { is_expected.to be true }
+    end
+
+    # Parallel zero-padded value that both Neo4j and Memgraph accept.
+    context 'when LocalDateTime (zero-padded)' do
+      let(:param) { '2018-01-01T12:34:00' }
 
       it { is_expected.to be true }
     end
@@ -107,9 +121,16 @@ RSpec.describe Neo4j::Driver::Types::LocalDateTime do
       end
     end
 
-    # Memgraph requires zero-padded YYYY-MM-DD; it rejects single-digit month/day like '2018-1-1'.
-    context 'when LocalDateTime', memgraph: false do
+    # Memgraph rejects single-digit month/day; kept for Neo4j's lenient parsing.
+    context 'when LocalDateTime (single-digit month/day)', memgraph: false do
       let(:param) { '2018-1-1T12:34:00' }
+
+      it { is_expected.to be true }
+    end
+
+    # Parallel zero-padded value that both Neo4j and Memgraph accept.
+    context 'when LocalDateTime (zero-padded)' do
+      let(:param) { '2018-01-01T12:34:00' }
 
       it { is_expected.to be true }
     end

--- a/spec/shared/neo4j/driver/types/local_date_time_spec.rb
+++ b/spec/shared/neo4j/driver/types/local_date_time_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe Neo4j::Driver::Types::LocalDateTime do
 
     let(:function) { %{localdatetime("#{localdatetime}")} }
 
-    context 'when LocalDateTime' do
+    # Memgraph requires zero-padded YYYY-MM-DD; it rejects single-digit month/day like '2018-1-1'.
+    context 'when LocalDateTime', memgraph: false do
       let(:localdatetime) { '2018-1-1T12:34:00' }
       let(:result) { described_class.parse(localdatetime) }
 
@@ -88,7 +89,8 @@ RSpec.describe Neo4j::Driver::Types::LocalDateTime do
       end
     end
 
-    context 'when LocalDateTime' do
+    # Memgraph requires zero-padded YYYY-MM-DD; it rejects single-digit month/day like '2018-1-1'.
+    context 'when LocalDateTime', memgraph: false do
       let(:param) { '2018-1-1T12:34:00' }
 
       it { is_expected.to be true }
@@ -105,7 +107,8 @@ RSpec.describe Neo4j::Driver::Types::LocalDateTime do
       end
     end
 
-    context 'when LocalDateTime' do
+    # Memgraph requires zero-padded YYYY-MM-DD; it rejects single-digit month/day like '2018-1-1'.
+    context 'when LocalDateTime', memgraph: false do
       let(:param) { '2018-1-1T12:34:00' }
 
       it { is_expected.to be true }

--- a/spec/shared/neo4j/driver/types/offset_time_spec.rb
+++ b/spec/shared/neo4j/driver/types/offset_time_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe Neo4j::Driver::Types::OffsetTime do
     end
   end
 
-  describe 'cypher functions' do
+  # Memgraph has no time()/OffsetTime (zoned time) type or function.
+  describe 'cypher functions', memgraph: false do
     subject do
       driver.session do |session|
         session.execute_write { |tx| tx.run("RETURN #{function}").single.first }
@@ -60,16 +61,14 @@ RSpec.describe Neo4j::Driver::Types::OffsetTime do
 
     let(:function) { %{time("#{offset_time}")} }
 
-    # Memgraph has no time()/OffsetTime (zoned time) type or function.
-    context 'when Time (UTC)', memgraph: false do
+    context 'when Time (UTC)' do
       let(:offset_time) { '12:34:00Z' }
       let(:result) { described_class.parse(offset_time) }
 
       it { is_expected.to eq result }
     end
 
-    # Memgraph has no time()/OffsetTime (zoned time) type or function.
-    context 'when Time (+3:30)', memgraph: false do
+    context 'when Time (+3:30)' do
       let(:offset_time) { '12:34:00+03:30' }
       let(:result) { described_class.parse(offset_time) }
 
@@ -77,7 +76,8 @@ RSpec.describe Neo4j::Driver::Types::OffsetTime do
     end
   end
 
-  describe 'offset_time roundtrip ruby check' do
+  # Memgraph has no time()/OffsetTime (zoned time) type or function.
+  describe 'offset_time roundtrip ruby check', memgraph: false do
     subject do
       driver.session do |session|
         session.execute_write do |tx|
@@ -87,15 +87,15 @@ RSpec.describe Neo4j::Driver::Types::OffsetTime do
       end
     end
 
-    # Memgraph has no time()/OffsetTime (zoned time) type or function.
-    context 'when Time', memgraph: false do
+    context 'when Time' do
       let(:param) { '12:34:00-05:00' }
 
       it { is_expected.to be true }
     end
   end
 
-  describe 'offset_time roundtrip neo4j check' do
+  # Memgraph has no time()/OffsetTime (zoned time) type or function.
+  describe 'offset_time roundtrip neo4j check', memgraph: false do
     subject do
       driver.session do |session|
         session.execute_write do |tx|
@@ -105,8 +105,7 @@ RSpec.describe Neo4j::Driver::Types::OffsetTime do
       end
     end
 
-    # Memgraph has no time()/OffsetTime (zoned time) type or function.
-    context 'when Time', memgraph: false do
+    context 'when Time' do
       let(:param) { '12:34:00-05:00' }
 
       it { is_expected.to be true }

--- a/spec/shared/neo4j/driver/types/offset_time_spec.rb
+++ b/spec/shared/neo4j/driver/types/offset_time_spec.rb
@@ -60,14 +60,16 @@ RSpec.describe Neo4j::Driver::Types::OffsetTime do
 
     let(:function) { %{time("#{offset_time}")} }
 
-    context 'when Time (UTC)' do
+    # Memgraph has no time()/OffsetTime (zoned time) type or function.
+    context 'when Time (UTC)', memgraph: false do
       let(:offset_time) { '12:34:00Z' }
       let(:result) { described_class.parse(offset_time) }
 
       it { is_expected.to eq result }
     end
 
-    context 'when Time (+3:30)' do
+    # Memgraph has no time()/OffsetTime (zoned time) type or function.
+    context 'when Time (+3:30)', memgraph: false do
       let(:offset_time) { '12:34:00+03:30' }
       let(:result) { described_class.parse(offset_time) }
 
@@ -85,7 +87,8 @@ RSpec.describe Neo4j::Driver::Types::OffsetTime do
       end
     end
 
-    context 'when Time' do
+    # Memgraph has no time()/OffsetTime (zoned time) type or function.
+    context 'when Time', memgraph: false do
       let(:param) { '12:34:00-05:00' }
 
       it { is_expected.to be true }
@@ -102,7 +105,8 @@ RSpec.describe Neo4j::Driver::Types::OffsetTime do
       end
     end
 
-    context 'when Time' do
+    # Memgraph has no time()/OffsetTime (zoned time) type or function.
+    context 'when Time', memgraph: false do
       let(:param) { '12:34:00-05:00' }
 
       it { is_expected.to be true }

--- a/spec/shared/neo4j/driver/types_spec.rb
+++ b/spec/shared/neo4j/driver/types_spec.rb
@@ -118,7 +118,8 @@ RSpec.describe Neo4j::Driver do
     its(:z) { is_expected.to be_within(DELTA).of(4) }
   end
 
-  context 'when bytes' do
+  # Memgraph does not support the Bolt byte-array type; passing packed bytes errors server-side.
+  context 'when bytes', memgraph: false do
     let(:param) { [1, 2, 3].pack('C*') }
 
     it { is_expected.to eq param }

--- a/spec/shared/support/driver_helper.rb
+++ b/spec/shared/support/driver_helper.rb
@@ -17,9 +17,19 @@ module DriverHelper
 
     def port = ENV.fetch('TEST_NEO4J_PORT', 7687)
 
+    # Memgraph runs with auth disabled by default; TEST_NEO4J_AUTH=none selects
+    # AuthTokens.none so the shared suite can target it unchanged.
+    def auth_token
+      ENV['TEST_NEO4J_AUTH'] == 'none' ? Neo4j::Driver::AuthTokens.none : basic_auth_token
+    end
+
     def basic_auth_token
       Neo4j::Driver::AuthTokens.basic(neo4j_user, neo4j_password)
     end
+
+    # True when the suite is being run against Memgraph rather than Neo4j.
+    # Drives the `memgraph: false` exclusion for Neo4j-only specs.
+    def memgraph? = ENV.key?('TEST_MEMGRAPH')
 
     def neo4j_user = ENV.fetch('TEST_NEO4J_USER', 'neo4j')
 
@@ -29,7 +39,7 @@ module DriverHelper
 
     def driver
       self.single_driver ||= Neo4j::Driver::GraphDatabase.driver(
-        uri, basic_auth_token,
+        uri, auth_token,
         max_transaction_retry_time: 2,
         connection_timeout: 3
         # logger: ActiveSupport::Logger.new(IO::NULL, level: ::Logger::DEBUG)

--- a/spec/shared/support/driver_helper.rb
+++ b/spec/shared/support/driver_helper.rb
@@ -17,12 +17,6 @@ module DriverHelper
 
     def port = ENV.fetch('TEST_NEO4J_PORT', 7687)
 
-    # Memgraph runs with auth disabled by default; TEST_NEO4J_AUTH=none selects
-    # AuthTokens.none so the shared suite can target it unchanged.
-    def auth_token
-      ENV['TEST_NEO4J_AUTH'] == 'none' ? Neo4j::Driver::AuthTokens.none : basic_auth_token
-    end
-
     def basic_auth_token
       Neo4j::Driver::AuthTokens.basic(neo4j_user, neo4j_password)
     end
@@ -39,7 +33,7 @@ module DriverHelper
 
     def driver
       self.single_driver ||= Neo4j::Driver::GraphDatabase.driver(
-        uri, auth_token,
+        uri, basic_auth_token,
         max_transaction_retry_time: 2,
         connection_timeout: 3
         # logger: ActiveSupport::Logger.new(IO::NULL, level: ::Logger::DEBUG)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,12 @@ RSpec.configure do |config|
   # byte params, month-durations, server-version assertions). The rest of the
   # shared suite runs unchanged. See docs/memgraph.md.
   config.filter_run_excluding memgraph: false if memgraph?
+  # A few specs pass on the MRI flavor against Memgraph (on both CRuby and the
+  # JVM) but fail on the JRuby/Java-driver flavor — the Java driver's own behavior
+  # against Memgraph, not an MRI gap or a platform effect (proven by the
+  # mri-flavor-on-JVM CI row passing). `Loader.jruby?` is true only for that
+  # flavor (false under NEO4J_DRIVER_FORCE_MRI), so this skips exactly that cell.
+  config.filter_run_excluding memgraph_jruby: false if memgraph? && Neo4j::Driver::Loader.jruby?
   config.exclude_pattern = "#{Neo4j::Driver::Loader.jruby? ? 'mri' : 'jruby'}/**/*_spec.rb"
   Neo4j::Driver::Internal::Deprecator.deprecator.behavior = :silence
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,11 @@ RSpec.configure do |config|
   import_dir = ENV.fetch('TEST_NEO4J_IMPORT_DIR', nil)
   usable_import_dir = import_dir && !import_dir.empty? && Dir.exist?(import_dir) && File.writable?(import_dir)
   config.filter_run_excluding csv: true unless usable_import_dir
+  # When targeting Memgraph, skip specs marked `memgraph: false` — Neo4j-only
+  # features (routing, bookmarks, multi-database admin, APOC, auth management,
+  # byte params, month-durations, server-version assertions). The rest of the
+  # shared suite runs unchanged. See docs/memgraph.md.
+  config.filter_run_excluding memgraph: false if memgraph?
   config.exclude_pattern = "#{Neo4j::Driver::Loader.jruby? ? 'mri' : 'jruby'}/**/*_spec.rb"
   Neo4j::Driver::Internal::Deprecator.deprecator.behavior = :silence
 end


### PR DESCRIPTION
Makes Memgraph **another target of the existing shared suite** — the same way the suite already runs against the MRI and JRuby flavors — instead of a parallel set of Memgraph-specific specs. A huge subset of the common specs runs unchanged; only the Neo4j-only examples are tagged and skipped.

## Mechanism

- **`spec_helper`**: `config.filter_run_excluding memgraph: false if memgraph?` — mirrors the existing `auth: :none` / `csv:` conditional excludes. Against Neo4j the tag is **inert** (all 572 examples still run); against Memgraph the Neo4j-only ones are skipped.
- **`driver_helper`**: env-driven target selection — `TEST_NEO4J_AUTH=none` → `AuthTokens.none` (Memgraph runs auth-disabled), and a `memgraph?` predicate keyed on `TEST_MEMGRAPH`.
- **107 examples** across 24 shared spec files tagged `memgraph: false` + a one-line reason, at the tightest granularity (passing siblings keep running). Every one is a genuine Neo4j-vs-Memgraph difference — error mapping to base `Neo4jException` (Memgraph emits no Neo4j `Neo.*` status codes), `neo4j://` routing, bookmarks, multi-database, byte params, duration/temporal normalization, summary/plan/profile shape, auth. **No driver bugs surfaced.**

## CI (same workflow, same invocation)

- **`rspec-memgraph`** in `specs.yml` — the *identical* `bundle exec rspec` run against a `memgraph/memgraph` service container with `TEST_MEMGRAPH=1` (+ auth-none, `memgraph` db).
- **`memgraph-success`** — version-free aggregator gate mirroring `rspec-success`; **not yet in the ruleset** (promote once stable).

## Coverage

| Mode | Examples run |
|---|---|
| Neo4j (no `TEST_MEMGRAPH`) | 572 (unchanged) |
| Memgraph (`TEST_MEMGRAPH=1`) | **465, 0 failures** |

Verified locally against Memgraph v3.12.0.

Run it locally:
```bash
docker run -d -p 7687:7687 memgraph/memgraph
TEST_MEMGRAPH=1 TEST_NEO4J_AUTH=none TEST_NEO4J_DATABASE=memgraph NEO4J_VERSION=5.11.0 bundle exec rspec
```

### Changed from the initial approach
Replaces the earlier parallel `spec/memgraph/compatibility_spec.rb` + standalone `memgraph.yml` with this shared-suite-as-target design (per review direction). `docs/memgraph.md` is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Memgraph 3.12.0 compatibility coverage on CRuby and JRuby.
  * Added shared-suite setup instructions for local and continuous integration testing.

* **Improvements**
  * Expanded compatibility for temporal values, durations, errors, result streams, and transactions.
  * Improved cross-driver error classification and authentication handling.

* **Documentation**
  * Documented Memgraph authentication, bookmarks, routing, temporal precision, query behavior, and known feature differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->